### PR TITLE
Fixed typo: Relateds -> Related

### DIFF
--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -150,7 +150,7 @@
     <string name="drag_pill">Drag pill</string>
     <string name="profile_picture">Profile picture</string>
     <string name="error_not_found">Not found</string>
-    <string name="relateds">Relateds</string>
+    <string name="relateds">Related</string>
     <string name="view_on_mal">View on MAL</string>
     <string name="share">Share</string>
     <string name="sort_title">Title</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -150,7 +150,7 @@
     <string name="drag_pill">Drag pill</string>
     <string name="profile_picture">Profile picture</string>
     <string name="error_not_found">Not found</string>
-    <string name="relateds">Relateds</string>
+    <string name="relateds">Related</string>
     <string name="view_on_mal">View on MAL</string>
     <string name="share">Share</string>
     <string name="sort_title">Title</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -149,7 +149,7 @@
     <string name="drag_pill">Drag pill</string>
     <string name="profile_picture">Profile picture</string>
     <string name="error_not_found">Not found</string>
-    <string name="relateds">Relateds</string>
+    <string name="relateds">Related</string>
     <string name="view_on_mal">View on MAL</string>
     <string name="share">Share</string>
     <string name="sort_title">Title</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,7 +154,7 @@
     <string name="drag_pill">Drag pill</string>
     <string name="profile_picture">Profile picture</string>
     <string name="error_not_found">Not found</string>
-    <string name="relateds">Relateds</string>
+    <string name="relateds">Related</string>
     <string name="view_on_mal">View on MAL</string>
     <string name="share">Share</string>
     <string name="sort_title">Title</string>


### PR DESCRIPTION
Changed 4 occurrences of 'Relateds' to 'Related'
The `name="relateds"` should also be changed,
but I didn't do it because something might break