### PR TITLE
Implement a better collapsable top app bar

### DIFF
--- a/app/src/main/java/com/axiel7/moelist/uicompose/MainActivity.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/MainActivity.kt
@@ -315,7 +315,9 @@ fun MainView(
         MainNavigation(
             navController = navController,
             lastTabOpened = lastTabOpened,
-            padding = padding
+            padding = padding,
+            topBarHeightPx = topBarHeightPx,
+            topBarOffsetY = topBarOffsetY,
         )
     }
 }

--- a/app/src/main/java/com/axiel7/moelist/uicompose/MainActivity.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.clickable
@@ -41,6 +42,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -302,7 +304,8 @@ fun MainView(
             BottomNavBar(
                 navController = navController,
                 bottomBarState = bottomBarState,
-                lastTabOpened = lastTabOpened
+                lastTabOpened = lastTabOpened,
+                topBarOffsetY = topBarOffsetY,
             )
         },
         contentWindowInsets = WindowInsets.systemBars
@@ -435,8 +438,11 @@ fun MainTopAppBar(
 fun BottomNavBar(
     navController: NavController,
     bottomBarState: State<Boolean>,
-    lastTabOpened: Int
+    lastTabOpened: Int,
+    topBarOffsetY: Animatable<Float, AnimationVector1D>,
 ) {
+    val scope = rememberCoroutineScope()
+
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val isVisible by remember {
         derivedStateOf {
@@ -464,6 +470,10 @@ fun BottomNavBar(
                     label = { Text(text = stringResource(dest.title)) },
                     selected = selectedItem == index,
                     onClick = {
+                        scope.launch {
+                            topBarOffsetY.animateTo(0f)
+                        }
+
                         selectedItem = index
                         navController.navigate(dest.route) {
                             popUpTo(navController.graph.findStartDestination().id) {

--- a/app/src/main/java/com/axiel7/moelist/uicompose/Navigation.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/Navigation.kt
@@ -112,8 +112,9 @@ fun MainNavigation(
                 navigateToCalendar = {
                     navController.navigate(CALENDAR_DESTINATION)
                 },
-                modifier = Modifier
-                    .padding(top = topPadding, bottom = bottomPadding),
+                padding = padding,
+                topBarHeightPx = topBarHeightPx,
+                topBarOffsetY = topBarOffsetY,
             )
         }
 

--- a/app/src/main/java/com/axiel7/moelist/uicompose/Navigation.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/Navigation.kt
@@ -230,8 +230,6 @@ fun MainNavigation(
         navigation(startDestination = MORE_DESTINATION, route = BottomDestination.More.route) {
             composable(MORE_DESTINATION) {
                 MoreView(
-                    modifier = Modifier
-                        .padding(top = topPadding, bottom = bottomPadding),
                     navigateToSettings = {
                         navController.navigate(SETTINGS_DESTINATION)
                     },
@@ -240,7 +238,10 @@ fun MainNavigation(
                     },
                     navigateToAbout = {
                         navController.navigate(ABOUT_DESTINATION)
-                    }
+                    },
+                    padding = padding,
+                    topBarHeightPx = topBarHeightPx,
+                    topBarOffsetY = topBarOffsetY,
                 )
             }
             composable(SETTINGS_DESTINATION) {

--- a/app/src/main/java/com/axiel7/moelist/uicompose/Navigation.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/Navigation.kt
@@ -1,5 +1,7 @@
 package com.axiel7.moelist.uicompose
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -62,6 +64,8 @@ fun MainNavigation(
     navController: NavHostController,
     lastTabOpened: Int,
     padding: PaddingValues,
+    topBarHeightPx: Float,
+    topBarOffsetY: Animatable<Float, AnimationVector1D>,
 ) {
     val accessTokenPreference by PreferencesDataStore.rememberPreference(ACCESS_TOKEN_PREFERENCE_KEY, App.accessToken ?: "")
     val stringArrayType = remember { StringArrayNavType() }

--- a/app/src/main/java/com/axiel7/moelist/uicompose/Navigation.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/Navigation.kt
@@ -9,16 +9,20 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.navArgument
 import androidx.navigation.navigation
 import com.axiel7.moelist.App
@@ -57,6 +61,7 @@ import com.axiel7.moelist.uicompose.season.SEASON_CHART_DESTINATION
 import com.axiel7.moelist.uicompose.season.SeasonChartView
 import com.axiel7.moelist.uicompose.userlist.UserMediaListHostView
 import com.axiel7.moelist.uicompose.userlist.UserMediaListWithTabsView
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 @Composable
 fun MainNavigation(
@@ -68,6 +73,17 @@ fun MainNavigation(
 ) {
     val accessTokenPreference by PreferencesDataStore.rememberPreference(ACCESS_TOKEN_PREFERENCE_KEY, App.accessToken ?: "")
     val stringArrayType = remember { StringArrayNavType() }
+
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val systemUiController = rememberSystemUiController()
+    val backgroundColor = MaterialTheme.colorScheme.background
+
+    LaunchedEffect(navBackStackEntry) {
+        if (BottomDestination.routes.contains(navBackStackEntry?.destination?.route)) {
+            systemUiController.setStatusBarColor(backgroundColor)
+        }
+        else systemUiController.setStatusBarColor(Color.Transparent)
+    }
 
     NavHost(
         navController = navController,

--- a/app/src/main/java/com/axiel7/moelist/uicompose/Navigation.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/Navigation.kt
@@ -2,7 +2,6 @@ package com.axiel7.moelist.uicompose
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -69,14 +68,6 @@ fun MainNavigation(
 ) {
     val accessTokenPreference by PreferencesDataStore.rememberPreference(ACCESS_TOKEN_PREFERENCE_KEY, App.accessToken ?: "")
     val stringArrayType = remember { StringArrayNavType() }
-    val topPadding by animateDpAsState(
-        targetValue = padding.calculateTopPadding(),
-        label = "top_bar_padding"
-    )
-    val bottomPadding by animateDpAsState(
-        targetValue = padding.calculateBottomPadding(),
-        label = "bottom_bar_padding"
-    )
 
     NavHost(
         navController = navController,
@@ -174,25 +165,29 @@ fun MainNavigation(
                 if (App.useListTabs)
                     UserMediaListWithTabsView(
                         mediaType = MediaType.ANIME,
-                        modifier = Modifier.padding(top = topPadding, bottom = bottomPadding),
                         navigateToMediaDetails = { mediaType, mediaId ->
                             navController.navigate(
                                 MEDIA_DETAILS_DESTINATION
                                     .replace("{mediaType}", mediaType.name)
                                     .replace("{mediaId}", mediaId.toString())
                             )
-                        }
+                        },
+                        topBarHeightPx = topBarHeightPx,
+                        topBarOffsetY = topBarOffsetY,
+                        padding = padding
                     )
                 else UserMediaListHostView(
                     mediaType = MediaType.ANIME,
-                    modifier = Modifier.padding(top = topPadding, bottom = bottomPadding),
                     navigateToMediaDetails = { mediaType, mediaId ->
                         navController.navigate(
                             MEDIA_DETAILS_DESTINATION
                                 .replace("{mediaType}", mediaType.name)
                                 .replace("{mediaId}", mediaId.toString())
                         )
-                    }
+                    },
+                    topBarHeightPx = topBarHeightPx,
+                    topBarOffsetY = topBarOffsetY,
+                    padding = padding
                 )
             }
         }
@@ -204,25 +199,29 @@ fun MainNavigation(
                 if (App.useListTabs)
                     UserMediaListWithTabsView(
                         mediaType = MediaType.MANGA,
-                        modifier = Modifier.padding(top = topPadding, bottom = bottomPadding),
                         navigateToMediaDetails = { mediaType, mediaId ->
                             navController.navigate(
                                 MEDIA_DETAILS_DESTINATION
                                     .replace("{mediaType}", mediaType.name)
                                     .replace("{mediaId}", mediaId.toString())
                             )
-                        }
+                        },
+                        topBarHeightPx = topBarHeightPx,
+                        topBarOffsetY = topBarOffsetY,
+                        padding = padding
                     )
                 else UserMediaListHostView(
                     mediaType = MediaType.MANGA,
-                    modifier = Modifier.padding(top = topPadding, bottom = bottomPadding),
                     navigateToMediaDetails = { mediaType, mediaId ->
                         navController.navigate(
                             MEDIA_DETAILS_DESTINATION
                                 .replace("{mediaType}", mediaType.name)
                                 .replace("{mediaId}", mediaId.toString())
                         )
-                    }
+                    },
+                    topBarHeightPx = topBarHeightPx,
+                    topBarOffsetY = topBarOffsetY,
+                    padding = padding
                 )
             }
         }

--- a/app/src/main/java/com/axiel7/moelist/uicompose/base/BottomDestination.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/base/BottomDestination.kt
@@ -47,6 +47,8 @@ sealed class BottomDestination(
     companion object {
         val values = listOf(Home, AnimeList, MangaList, More)
 
+        val routes = values.map { it.route }
+
         fun String.toBottomDestinationIndex() = when (this) {
             Home.value -> 0
             AnimeList.value -> 1

--- a/app/src/main/java/com/axiel7/moelist/uicompose/composables/ModifierCollapsable.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/composables/ModifierCollapsable.kt
@@ -1,0 +1,61 @@
+package com.axiel7.moelist.uicompose.composables
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.gestures.animateScrollBy
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import kotlinx.coroutines.launch
+import kotlin.math.abs
+
+fun Modifier.collapsable(
+    state: ScrollableState,
+    topBarHeightPx: Float,
+    topBarOffsetY: Animatable<Float, AnimationVector1D>,
+) = composed {
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(key1 = state.isScrollInProgress) {
+        if (!state.isScrollInProgress && topBarOffsetY.value != 0f && topBarOffsetY.value != -topBarHeightPx) {
+            val half = topBarHeightPx / 2
+            val oldOffsetY = topBarOffsetY.value
+
+            val targetOffsetY = when {
+                abs(topBarOffsetY.value) >= half -> -topBarHeightPx
+                else -> 0f
+            }
+
+            launch {
+                state.animateScrollBy(oldOffsetY - targetOffsetY)
+            }
+
+            launch {
+                topBarOffsetY.animateTo(targetOffsetY)
+            }
+        }
+    }
+
+    nestedScroll(
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                scope.launch {
+                    topBarOffsetY.snapTo(
+                        targetValue = (topBarOffsetY.value + available.y).coerceIn(
+                            minimumValue = -topBarHeightPx,
+                            maximumValue = 0f,
+                        )
+                    )
+                }
+
+                return Offset.Zero
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/axiel7/moelist/uicompose/composables/ModifierCollapsable.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/composables/ModifierCollapsable.kt
@@ -46,12 +46,14 @@ fun Modifier.collapsable(
         object : NestedScrollConnection {
             override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
                 scope.launch {
-                    topBarOffsetY.snapTo(
-                        targetValue = (topBarOffsetY.value + available.y).coerceIn(
-                            minimumValue = -topBarHeightPx,
-                            maximumValue = 0f,
+                    if (state.canScrollForward) {
+                        topBarOffsetY.snapTo(
+                            targetValue = (topBarOffsetY.value + available.y).coerceIn(
+                                minimumValue = -topBarHeightPx,
+                                maximumValue = 0f,
+                            )
                         )
-                    )
+                    }
                 }
 
                 return Offset.Zero

--- a/app/src/main/java/com/axiel7/moelist/uicompose/home/HomeView.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/home/HomeView.kt
@@ -33,11 +33,13 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -68,6 +70,7 @@ import com.axiel7.moelist.uicompose.composables.collapsable
 import com.axiel7.moelist.uicompose.theme.MoeListTheme
 import com.axiel7.moelist.utils.ContextExtensions.showToast
 import com.axiel7.moelist.utils.SeasonCalendar
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import kotlin.random.Random
 
 const val HOME_DESTINATION = "home"
@@ -90,6 +93,15 @@ fun HomeView(
     val airingListState = rememberLazyListState()
     val seasonListState = rememberLazyListState()
     val recommendListState = rememberLazyListState()
+
+    val systemUiController = rememberSystemUiController()
+    val backgroundColor = MaterialTheme.colorScheme.background
+    DisposableEffect(systemUiController) {
+        systemUiController.setStatusBarColor(backgroundColor)
+        onDispose {
+            systemUiController.setStatusBarColor(Color.Transparent)
+        }
+    }
 
     LaunchedEffect(viewModel.message) {
         if (viewModel.showMessage) {

--- a/app/src/main/java/com/axiel7/moelist/uicompose/home/HomeView.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/home/HomeView.kt
@@ -1,6 +1,8 @@
 package com.axiel7.moelist.uicompose.home
 
 import androidx.annotation.DrawableRes
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
@@ -9,6 +11,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -31,6 +34,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -60,6 +64,7 @@ import com.axiel7.moelist.uicompose.composables.MediaItemVertical
 import com.axiel7.moelist.uicompose.composables.MediaItemVerticalPlaceholder
 import com.axiel7.moelist.uicompose.composables.MediaPoster
 import com.axiel7.moelist.uicompose.composables.SmallScoreIndicator
+import com.axiel7.moelist.uicompose.composables.collapsable
 import com.axiel7.moelist.uicompose.theme.MoeListTheme
 import com.axiel7.moelist.utils.ContextExtensions.showToast
 import com.axiel7.moelist.utils.SeasonCalendar
@@ -76,6 +81,9 @@ fun HomeView(
     navigateToRanking: (MediaType) -> Unit,
     navigateToSeasonChart: () -> Unit,
     navigateToCalendar: () -> Unit,
+    topBarHeightPx: Float,
+    topBarOffsetY: Animatable<Float, AnimationVector1D>,
+    padding: PaddingValues,
 ) {
     val context = LocalContext.current
     val viewModel: HomeViewModel = viewModel()
@@ -96,8 +104,16 @@ fun HomeView(
     }
 
     Column(
-        modifier = modifier.verticalScroll(scrollState)
+        modifier = modifier
+            .collapsable(
+                state = scrollState,
+                topBarHeightPx = topBarHeightPx,
+                topBarOffsetY = topBarOffsetY,
+            )
+            .verticalScroll(scrollState)
     ) {
+        Spacer(modifier = Modifier.height(padding.calculateTopPadding()))
+        
         // Chips
         Row(
             modifier = Modifier.padding(top = 10.dp, start = 8.dp, end = 16.dp)
@@ -156,8 +172,7 @@ fun HomeView(
                     textAlign = TextAlign.Center
                 )
             }
-        }
-        else LazyRow(
+        } else LazyRow(
             modifier = Modifier
                 .padding(top = 8.dp)
                 .sizeIn(minHeight = MEDIA_POSTER_SMALL_HEIGHT.dp),
@@ -322,6 +337,8 @@ fun HomeView(
                 )
             }
         }
+        
+        Spacer(modifier = Modifier.height(padding.calculateBottomPadding()))
     }
 }
 
@@ -429,7 +446,10 @@ fun HomePreview() {
                 navigateToMediaDetails = { _, _ -> },
                 navigateToRanking = {},
                 navigateToSeasonChart = {},
-                navigateToCalendar = {}
+                navigateToCalendar = {},
+                padding = PaddingValues(),
+                topBarHeightPx = 0f,
+                topBarOffsetY = remember { Animatable(0f) }
             )
         }
     }

--- a/app/src/main/java/com/axiel7/moelist/uicompose/home/HomeView.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/home/HomeView.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -33,13 +32,11 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -70,7 +67,6 @@ import com.axiel7.moelist.uicompose.composables.collapsable
 import com.axiel7.moelist.uicompose.theme.MoeListTheme
 import com.axiel7.moelist.utils.ContextExtensions.showToast
 import com.axiel7.moelist.utils.SeasonCalendar
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import kotlin.random.Random
 
 const val HOME_DESTINATION = "home"
@@ -93,15 +89,6 @@ fun HomeView(
     val airingListState = rememberLazyListState()
     val seasonListState = rememberLazyListState()
     val recommendListState = rememberLazyListState()
-
-    val systemUiController = rememberSystemUiController()
-    val backgroundColor = MaterialTheme.colorScheme.background
-    DisposableEffect(systemUiController) {
-        systemUiController.setStatusBarColor(backgroundColor)
-        onDispose {
-            systemUiController.setStatusBarColor(Color.Transparent)
-        }
-    }
 
     LaunchedEffect(viewModel.message) {
         if (viewModel.showMessage) {

--- a/app/src/main/java/com/axiel7/moelist/uicompose/home/HomeView.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/home/HomeView.kt
@@ -76,7 +76,6 @@ const val HOME_DESTINATION = "home"
 @Composable
 fun HomeView(
     isLoggedIn: Boolean,
-    modifier: Modifier = Modifier,
     navigateToMediaDetails: (MediaType, Int) -> Unit,
     navigateToRanking: (MediaType) -> Unit,
     navigateToSeasonChart: () -> Unit,
@@ -104,16 +103,15 @@ fun HomeView(
     }
 
     Column(
-        modifier = modifier
+        modifier = Modifier
             .collapsable(
                 state = scrollState,
                 topBarHeightPx = topBarHeightPx,
                 topBarOffsetY = topBarOffsetY,
             )
             .verticalScroll(scrollState)
+            .padding(padding)
     ) {
-        Spacer(modifier = Modifier.height(padding.calculateTopPadding()))
-        
         // Chips
         Row(
             modifier = Modifier.padding(top = 10.dp, start = 8.dp, end = 16.dp)
@@ -337,8 +335,6 @@ fun HomeView(
                 )
             }
         }
-        
-        Spacer(modifier = Modifier.height(padding.calculateBottomPadding()))
     }
 }
 

--- a/app/src/main/java/com/axiel7/moelist/uicompose/more/MoreView.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/more/MoreView.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -31,7 +30,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -47,7 +45,6 @@ import com.axiel7.moelist.utils.Constants.GITHUB_ISSUES_URL
 import com.axiel7.moelist.utils.ContextExtensions.openAction
 import com.axiel7.moelist.utils.ContextExtensions.openLink
 import com.axiel7.moelist.utils.UseCases.logOut
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import kotlinx.coroutines.launch
 
 const val MORE_TAB_DESTINATION = "more_tab"
@@ -65,15 +62,6 @@ fun MoreView(
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
-
-    val systemUiController = rememberSystemUiController()
-    val backgroundColor = MaterialTheme.colorScheme.background
-    DisposableEffect(systemUiController) {
-        systemUiController.setStatusBarColor(backgroundColor)
-        onDispose {
-            systemUiController.setStatusBarColor(Color.Transparent)
-        }
-    }
 
     var openFeedbackDialog by remember { mutableStateOf(false) }
 

--- a/app/src/main/java/com/axiel7/moelist/uicompose/more/MoreView.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/more/MoreView.kt
@@ -52,7 +52,6 @@ const val MORE_DESTINATION = "more"
 
 @Composable
 fun MoreView(
-    modifier: Modifier = Modifier,
     navigateToSettings: () -> Unit,
     navigateToNotifications: () -> Unit,
     navigateToAbout: () -> Unit,
@@ -72,7 +71,7 @@ fun MoreView(
     }
 
     Column(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxSize()
             .collapsable(
                 state = scrollState,
@@ -80,9 +79,8 @@ fun MoreView(
                 topBarOffsetY = topBarOffsetY,
             )
             .verticalScroll(scrollState)
+            .padding(padding)
     ) {
-        Spacer(modifier = Modifier.height(padding.calculateTopPadding()))
-
         Icon(
             painter = painterResource(R.drawable.ic_moelist_logo),
             contentDescription = stringResource(R.string.app_name),
@@ -147,8 +145,6 @@ fun MoreView(
                 coroutineScope.launch { context.logOut() }
             }
         )
-
-        Spacer(modifier = Modifier.height(padding.calculateBottomPadding()))
     }
 }
 

--- a/app/src/main/java/com/axiel7/moelist/uicompose/more/MoreView.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/more/MoreView.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -30,6 +31,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -45,6 +47,7 @@ import com.axiel7.moelist.utils.Constants.GITHUB_ISSUES_URL
 import com.axiel7.moelist.utils.ContextExtensions.openAction
 import com.axiel7.moelist.utils.ContextExtensions.openLink
 import com.axiel7.moelist.utils.UseCases.logOut
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import kotlinx.coroutines.launch
 
 const val MORE_TAB_DESTINATION = "more_tab"
@@ -62,6 +65,16 @@ fun MoreView(
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
+
+    val systemUiController = rememberSystemUiController()
+    val backgroundColor = MaterialTheme.colorScheme.background
+    DisposableEffect(systemUiController) {
+        systemUiController.setStatusBarColor(backgroundColor)
+        onDispose {
+            systemUiController.setStatusBarColor(Color.Transparent)
+        }
+    }
+
     var openFeedbackDialog by remember { mutableStateOf(false) }
 
     if (openFeedbackDialog) {

--- a/app/src/main/java/com/axiel7/moelist/uicompose/more/MoreView.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/more/MoreView.kt
@@ -1,11 +1,12 @@
 package com.axiel7.moelist.uicompose.more
 
-import android.content.Intent
-import android.net.Uri
 import androidx.annotation.DrawableRes
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -36,6 +37,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.axiel7.moelist.R
+import com.axiel7.moelist.uicompose.composables.collapsable
 import com.axiel7.moelist.uicompose.theme.MoeListTheme
 import com.axiel7.moelist.utils.Constants
 import com.axiel7.moelist.utils.Constants.DISCORD_SERVER_URL
@@ -54,6 +56,9 @@ fun MoreView(
     navigateToSettings: () -> Unit,
     navigateToNotifications: () -> Unit,
     navigateToAbout: () -> Unit,
+    topBarHeightPx: Float,
+    topBarOffsetY: Animatable<Float, AnimationVector1D>,
+    padding: PaddingValues,
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
@@ -69,8 +74,15 @@ fun MoreView(
     Column(
         modifier = modifier
             .fillMaxSize()
+            .collapsable(
+                state = scrollState,
+                topBarHeightPx = topBarHeightPx,
+                topBarOffsetY = topBarOffsetY,
+            )
             .verticalScroll(scrollState)
     ) {
+        Spacer(modifier = Modifier.height(padding.calculateTopPadding()))
+
         Icon(
             painter = painterResource(R.drawable.ic_moelist_logo),
             contentDescription = stringResource(R.string.app_name),
@@ -135,6 +147,8 @@ fun MoreView(
                 coroutineScope.launch { context.logOut() }
             }
         )
+
+        Spacer(modifier = Modifier.height(padding.calculateBottomPadding()))
     }
 }
 
@@ -229,6 +243,9 @@ fun MorePreview() {
             navigateToSettings = {},
             navigateToNotifications = {},
             navigateToAbout = {},
+            padding = PaddingValues(),
+            topBarHeightPx = 0f,
+            topBarOffsetY = remember { Animatable(0f) }
         )
     }
 }

--- a/app/src/main/java/com/axiel7/moelist/uicompose/userlist/UserMediaListWithTabsView.kt
+++ b/app/src/main/java/com/axiel7/moelist/uicompose/userlist/UserMediaListWithTabsView.kt
@@ -1,7 +1,14 @@
 package com.axiel7.moelist.uicompose.userlist
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.MaterialTheme
@@ -12,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import com.axiel7.moelist.data.model.media.ListType
 import com.axiel7.moelist.data.model.media.MediaType
@@ -26,8 +34,10 @@ import kotlinx.coroutines.launch
 @Composable
 fun UserMediaListWithTabsView(
     mediaType: MediaType,
-    modifier: Modifier = Modifier,
     navigateToMediaDetails: (MediaType, Int) -> Unit,
+    topBarHeightPx: Float,
+    topBarOffsetY: Animatable<Float, AnimationVector1D>,
+    padding: PaddingValues,
 ) {
     val scope = rememberCoroutineScope()
     val tabRowItems = remember {
@@ -38,9 +48,21 @@ fun UserMediaListWithTabsView(
             ) }
     }
     val pagerState = rememberPagerState { tabRowItems.size }
+    val systemBarsPadding = WindowInsets.systemBars.asPaddingValues()
 
     Column(
-        modifier = modifier
+        modifier = Modifier
+            .padding(
+                top = padding.calculateTopPadding(),
+            )
+            .graphicsLayer {
+                val topPadding = padding.calculateTopPadding().value +
+                            systemBarsPadding.calculateTopPadding().value +
+                            systemBarsPadding.calculateBottomPadding().value
+
+                translationY = if (topBarOffsetY.value > -topPadding) topBarOffsetY.value
+                else -topPadding
+            }
     ) {
         ScrollableTabRow(
             selectedTabIndex = pagerState.currentPage,
@@ -65,11 +87,17 @@ fun UserMediaListWithTabsView(
             key = { tabRowItems[it].value }
         ) {
             UserMediaListView(
-                listType = ListType(
-                    status = tabRowItems[it].value,
-                    mediaType = mediaType
+                listType = ListType(status = tabRowItems[it].value, mediaType = mediaType),
+                modifier = Modifier.padding(
+                    bottom = systemBarsPadding.calculateBottomPadding()
                 ),
                 navigateToMediaDetails = navigateToMediaDetails,
+                topBarHeightPx = topBarHeightPx,
+                topBarOffsetY = topBarOffsetY,
+                contentPadding = PaddingValues(
+                    bottom = padding.calculateBottomPadding() +
+                            systemBarsPadding.calculateBottomPadding()
+                )
             )
         }//:Pager
     }//:Column


### PR DESCRIPTION
An answer for this commit 27a42900263d55f7db593e38b7adf1dd7f81851b

While it's harder to implement, but it doesn't degrade the scrolling performance. Please take a look of each commits description.

Already implemented in these screens:
- [x] Home
- [x] Anime
- [x] Manga
- [x] More

Result:

https://github.com/axiel7/MoeList/assets/52477630/8bec9429-3d65-4225-9108-552ac762e743
