### PR TITLE
Refactor Navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,8 +114,6 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-compose:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:$lifecycleVersion")
 
-    implementation("androidx.navigation:navigation-compose:2.7.6")
-
     implementation("androidx.glance:glance-appwidget:1.0.0")
 
     val accompanistVersion = "0.32.0"
@@ -151,4 +149,9 @@ dependencies {
     implementation("io.insert-koin:koin-androidx-compose")
     implementation("io.insert-koin:koin-androidx-compose-navigation")
     implementation("io.insert-koin:koin-androidx-workmanager")
+
+    //Serialized Navigation
+    val serializedNavigationVersion = "e23f84fc1f" // TODO: use proper versioning once the library is released
+    implementation("com.github.uragiristereo.serialized-navigation-extension:navigation-compose:$serializedNavigationVersion")
+    implementation("com.github.uragiristereo.serialized-navigation-extension:serializer-kotlinx:$serializedNavigationVersion")
 }

--- a/app/src/main/java/com/axiel7/moelist/App.kt
+++ b/app/src/main/java/com/axiel7/moelist/App.kt
@@ -7,6 +7,8 @@ import com.axiel7.moelist.di.networkModule
 import com.axiel7.moelist.di.repositoryModule
 import com.axiel7.moelist.di.viewModelModule
 import com.axiel7.moelist.di.workerModule
+import com.uragiristereo.serializednavigationextension.runtime.installSerializer
+import com.uragiristereo.serializednavigationextension.serializer.KotlinxSerializer
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.androidx.workmanager.koin.workManagerFactory
@@ -17,6 +19,8 @@ class App : Application(), KoinComponent {
 
     override fun onCreate() {
         super.onCreate()
+
+        installSerializer(KotlinxSerializer())
 
         startKoin {
             if (BuildConfig.IS_DEBUG) {

--- a/app/src/main/java/com/axiel7/moelist/ui/base/BottomDestination.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/base/BottomDestination.kt
@@ -6,9 +6,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.axiel7.moelist.R
-import com.axiel7.moelist.data.model.media.MediaType
-import com.axiel7.moelist.ui.base.navigation.NavArgument
-import com.axiel7.moelist.ui.base.navigation.NavDestination
+import com.axiel7.moelist.ui.base.navigation.Route
+import com.uragiristereo.serializednavigationextension.runtime.routeOf
 
 sealed class BottomDestination(
     val value: String,
@@ -19,7 +18,7 @@ sealed class BottomDestination(
 ) {
     data object Home : BottomDestination(
         value = "home",
-        route = NavDestination.HomeTab.route(),
+        route = routeOf<Route.Tab.Home>(),
         title = R.string.title_home,
         icon = R.drawable.ic_outline_home_24,
         iconSelected = R.drawable.ic_round_home_24
@@ -27,9 +26,7 @@ sealed class BottomDestination(
 
     data object AnimeList : BottomDestination(
         value = "anime",
-        route = NavDestination.AnimeTab.putArguments(
-            mapOf(NavArgument.MediaType to MediaType.ANIME.name)
-        ),
+        route = routeOf<Route.Tab.Anime>(),
         title = R.string.title_anime_list,
         icon = R.drawable.ic_outline_local_movies_24,
         iconSelected = R.drawable.ic_round_local_movies_24
@@ -37,9 +34,7 @@ sealed class BottomDestination(
 
     data object MangaList : BottomDestination(
         value = "manga",
-        route = NavDestination.MangaTab.putArguments(
-            mapOf(NavArgument.MediaType to MediaType.MANGA.name)
-        ),
+        route = routeOf<Route.Tab.Manga>(),
         title = R.string.title_manga_list,
         icon = R.drawable.ic_outline_book_24,
         iconSelected = R.drawable.ic_round_book_24
@@ -47,7 +42,7 @@ sealed class BottomDestination(
 
     data object Profile : BottomDestination(
         value = "profile",
-        route = NavDestination.Profile.route(),
+        route = routeOf<Route.Profile>(),
         title = R.string.title_profile,
         icon = R.drawable.ic_outline_person_24,
         iconSelected = R.drawable.ic_round_person_24
@@ -55,7 +50,7 @@ sealed class BottomDestination(
 
     data object More : BottomDestination(
         value = "more",
-        route = NavDestination.MoreTab.route(),
+        route = routeOf<Route.Tab.More>(),
         title = R.string.more,
         icon = R.drawable.ic_more_horizontal,
         iconSelected = R.drawable.ic_more_horizontal

--- a/app/src/main/java/com/axiel7/moelist/ui/base/navigation/NavActionManager.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/base/navigation/NavActionManager.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.remember
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.axiel7.moelist.data.model.media.MediaType
+import com.uragiristereo.serializednavigationextension.runtime.navigate
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
@@ -19,67 +20,60 @@ class NavActionManager(
     }
 
     fun toMediaRanking(mediaType: MediaType) {
-        navController.navigate(
-            NavDestination.MediaRanking
-                .putArguments(mapOf(NavArgument.MediaType to mediaType.name))
-        )
+        navController.navigate(Route.MediaRanking(mediaType))
     }
 
     fun toMediaDetails(mediaType: MediaType, id: Int) {
         navController.navigate(
-            NavDestination.MediaDetails
-                .putArguments(mapOf(
-                    NavArgument.MediaType to mediaType.name,
-                    NavArgument.MediaId to id.toString()
-                ))
+            Route.MediaDetails(
+                mediaType = mediaType,
+                mediaId = id,
+            )
         )
     }
 
     fun toCalendar() {
-        navController.navigate(NavDestination.Calendar.route())
+        navController.navigate(Route.Calendar)
     }
 
     fun toSeasonChart() {
-        navController.navigate(NavDestination.SeasonChart.route())
+        navController.navigate(Route.SeasonChart)
     }
 
     fun toRecommendations() {
-        navController.navigate(NavDestination.Recommendations.route())
+        navController.navigate(Route.Recommendations)
     }
 
     fun toProfile() {
-        navController.navigate(NavDestination.Profile.route())
+        navController.navigate(Route.Profile)
     }
 
     fun toSearch() {
-        navController.navigate(NavDestination.Search.route())
+        navController.navigate(Route.Search)
     }
 
     fun toFullPoster(pictures: List<String>) {
-        navController.navigate(
-            NavDestination.FullPoster
-                .putArguments(mapOf(NavArgument.Pictures to pictures.toNavArgument()))
-        )
+        navController.navigate(Route.FullPoster(pictures))
     }
 
     fun toSettings() {
-        navController.navigate(NavDestination.Settings.route())
+        navController.navigate(Route.Settings)
     }
 
     fun toListStyleSettings() {
-        navController.navigate(NavDestination.ListStyleSettings.route())
+        navController.navigate(Route.ListStyleSettings)
     }
 
     fun toNotifications() {
-        navController.navigate(NavDestination.Notifications.route())
+        navController.navigate(Route.Notifications)
     }
 
     fun toAbout() {
-        navController.navigate(NavDestination.About.route())
+        navController.navigate(Route.About)
     }
 
     fun toCredits() {
-        navController.navigate(NavDestination.Credits.route())
+        navController.navigate(Route.Credits)
     }
 
     companion object {

--- a/app/src/main/java/com/axiel7/moelist/ui/base/navigation/Route.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/base/navigation/Route.kt
@@ -1,0 +1,64 @@
+package com.axiel7.moelist.ui.base.navigation
+
+import com.axiel7.moelist.data.model.media.MediaType
+import com.uragiristereo.serializednavigationextension.runtime.NavRoute
+import kotlinx.serialization.Serializable
+
+sealed interface Route : NavRoute {
+    sealed interface Tab : Route {
+        @Serializable
+        data object Home : Tab
+
+        @Serializable
+        data class Anime(val mediaType: String) : Tab
+
+        @Serializable
+        data class Manga(val mediaType: String) : Tab
+
+        @Serializable
+        data object More : Tab
+    }
+
+    @Serializable
+    data class MediaRanking(val mediaType: MediaType) : Route
+
+    @Serializable
+    data class MediaDetails(
+        val mediaType: MediaType,
+        val mediaId: Int,
+    ) : Route
+
+    @Serializable
+    data object Calendar : Route
+
+    @Serializable
+    data object SeasonChart : Route
+
+    @Serializable
+    data object Recommendations : Route
+
+    @Serializable
+    data object Profile : Route
+
+    @Serializable
+    data object Search : Route
+
+    @Serializable
+    data class FullPoster(val pictures: List<String>) : Route
+
+    @Serializable
+    data object Settings : Route
+
+    @Serializable
+    data object ListStyleSettings : Route
+
+    @Serializable
+    data object Notifications : Route
+
+    @Serializable
+    data object About : Route
+
+    @Serializable
+    data object Credits : Route
+}
+

--- a/app/src/main/java/com/axiel7/moelist/ui/details/MediaDetailsViewModel.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/details/MediaDetailsViewModel.kt
@@ -14,9 +14,10 @@ import com.axiel7.moelist.data.model.media.WeekDay
 import com.axiel7.moelist.data.repository.AnimeRepository
 import com.axiel7.moelist.data.repository.DefaultPreferencesRepository
 import com.axiel7.moelist.data.repository.MangaRepository
-import com.axiel7.moelist.ui.base.navigation.NavArgument
+import com.axiel7.moelist.ui.base.navigation.Route
 import com.axiel7.moelist.ui.base.viewmodel.BaseViewModel
 import com.axiel7.moelist.worker.NotificationWorkerManager
+import com.uragiristereo.serializednavigationextension.runtime.navArgsFlowOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -45,12 +46,9 @@ class MediaDetailsViewModel(
     defaultPreferencesRepository: DefaultPreferencesRepository,
 ) : BaseViewModel<MediaDetailsUiState>(), MediaDetailsEvent {
 
-    private val mediaType =
-        savedStateHandle.getStateFlow(NavArgument.MediaType.name, MediaType.ANIME.name)
-            .map { MediaType.valueOf(it) }
-
-    private val mediaId = savedStateHandle.getStateFlow<Int?>(NavArgument.MediaId.name, null)
-        .filterNotNull()
+    private val args = savedStateHandle.navArgsFlowOf<Route.MediaDetails>().filterNotNull()
+    private val mediaType = args.map { it.mediaType }
+    private val mediaId = args.map { it.mediaId }
 
     override val mutableUiState = MutableStateFlow(MediaDetailsUiState())
 

--- a/app/src/main/java/com/axiel7/moelist/ui/editmedia/EditMediaViewModel.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/editmedia/EditMediaViewModel.kt
@@ -10,9 +10,10 @@ import com.axiel7.moelist.data.model.media.ListStatus
 import com.axiel7.moelist.data.model.media.MediaType
 import com.axiel7.moelist.data.repository.AnimeRepository
 import com.axiel7.moelist.data.repository.MangaRepository
-import com.axiel7.moelist.ui.base.navigation.NavArgument
+import com.axiel7.moelist.ui.base.navigation.Route
 import com.axiel7.moelist.ui.base.viewmodel.BaseViewModel
 import com.axiel7.moelist.utils.DateUtils
+import com.uragiristereo.serializednavigationextension.runtime.navArgsFlowOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -31,10 +32,9 @@ class EditMediaViewModel(
     private val mangaRepository: MangaRepository,
 ) : BaseViewModel<EditMediaUiState>(), EditMediaEvent {
 
-    private val mediaType =
-        savedStateHandle.getStateFlow(NavArgument.MediaType.name, MediaType.ANIME.name)
-            .map { MediaType.valueOf(it) }
-            .stateIn(viewModelScope, SharingStarted.Eagerly, MediaType.ANIME)
+    private val mediaType = savedStateHandle.navArgsFlowOf<Route.MediaDetails>()
+        .map { it?.mediaType ?: MediaType.ANIME }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, MediaType.ANIME)
 
     override val mutableUiState = MutableStateFlow(EditMediaUiState(mediaType = mediaType.value))
 

--- a/app/src/main/java/com/axiel7/moelist/ui/fullposter/FullPosterView.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/fullposter/FullPosterView.kt
@@ -40,7 +40,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun FullPosterView(
-    pictures: Array<String>,
+    pictures: List<String>,
     navActionManager: NavActionManager,
 ) {
     val context = LocalContext.current
@@ -123,7 +123,7 @@ fun FullPosterPreview() {
     MoeListTheme {
         Surface {
             FullPosterView(
-                pictures = arrayOf("", ""),
+                pictures = listOf("", ""),
                 navActionManager = NavActionManager.rememberNavActionManager()
             )
         }

--- a/app/src/main/java/com/axiel7/moelist/ui/main/MainNavigation.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/main/MainNavigation.kt
@@ -12,14 +12,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import com.axiel7.moelist.R
 import com.axiel7.moelist.data.model.media.MediaType
 import com.axiel7.moelist.ui.base.BottomDestination
 import com.axiel7.moelist.ui.base.navigation.NavActionManager
-import com.axiel7.moelist.ui.base.navigation.NavActionManager.Companion.rememberNavActionManager
-import com.axiel7.moelist.ui.base.navigation.NavArgument
-import com.axiel7.moelist.ui.base.navigation.NavDestination
+import com.axiel7.moelist.ui.base.navigation.Route
 import com.axiel7.moelist.ui.calendar.CalendarView
 import com.axiel7.moelist.ui.composables.DefaultScaffoldWithTopAppBar
 import com.axiel7.moelist.ui.details.MediaDetailsView
@@ -39,6 +36,7 @@ import com.axiel7.moelist.ui.search.SearchHostView
 import com.axiel7.moelist.ui.season.SeasonChartView
 import com.axiel7.moelist.ui.userlist.UserMediaListWithFabView
 import com.axiel7.moelist.ui.userlist.UserMediaListWithTabsView
+import com.uragiristereo.serializednavigationextension.navigation.compose.composable
 
 @Composable
 fun MainNavigation(
@@ -63,7 +61,7 @@ fun MainNavigation(
         popEnterTransition = { fadeIn(tween(400)) },
         popExitTransition = { fadeOut(tween(400)) }
     ) {
-        composable(BottomDestination.Home.route) {
+        composable<Route.Tab.Home> {
             HomeView(
                 isLoggedIn = isLoggedIn,
                 navActionManager = navActionManager,
@@ -73,10 +71,7 @@ fun MainNavigation(
             )
         }
 
-        composable(
-            route = BottomDestination.AnimeList.route,
-            arguments = NavDestination.AnimeTab.namedNavArguments
-        ) {
+        composable<Route.Tab.Anime> {
             if (!isLoggedIn) {
                 LoginView()
             } else {
@@ -102,10 +97,7 @@ fun MainNavigation(
             }
         }
 
-        composable(
-            route = BottomDestination.MangaList.route,
-            arguments = NavDestination.MangaTab.namedNavArguments
-        ) {
+        composable<Route.Tab.Manga> {
             if (!isLoggedIn) {
                 LoginView()
             } else {
@@ -131,7 +123,7 @@ fun MainNavigation(
             }
         }
 
-        composable(BottomDestination.More.route) {
+        composable<Route.Tab.More> {
             MoreView(
                 navActionManager = navActionManager,
                 padding = padding,
@@ -140,90 +132,81 @@ fun MainNavigation(
             )
         }
 
-        composable(
-            route = NavDestination.MediaRanking.route(),
-            arguments = NavDestination.MediaRanking.namedNavArguments
-        ) { navEntry ->
+        composable<Route.MediaRanking> {
+            val args = rememberNavArgsOf()
+
             MediaRankingView(
-                mediaType = MediaType.valueOf(
-                    navEntry.arguments?.getString(NavArgument.MediaType.name)
-                        ?: MediaType.ANIME.name
-                ),
+                mediaType = args?.mediaType ?: MediaType.ANIME,
                 isCompactScreen = isCompactScreen,
                 navActionManager = navActionManager,
             )
         }
 
-        composable(NavDestination.Calendar.route()) {
+        composable<Route.Calendar> {
             CalendarView(
                 navActionManager = navActionManager
             )
         }
 
-        composable(NavDestination.SeasonChart.route()) {
+        composable<Route.SeasonChart> {
             SeasonChartView(
                 navActionManager = navActionManager
             )
         }
 
-        composable(NavDestination.Recommendations.route()) {
+        composable<Route.Recommendations> {
             RecommendationsView(
                 navActionManager = navActionManager
             )
         }
 
-        composable(NavDestination.Settings.route()) {
+        composable<Route.Settings> {
             SettingsView(
                 navActionManager = navActionManager
             )
         }
 
-        composable(NavDestination.ListStyleSettings.route()) {
+        composable<Route.ListStyleSettings> {
             ListStyleSettingsView(
                 navActionManager = navActionManager
             )
         }
 
-        composable(NavDestination.Notifications.route()) {
+        composable<Route.Notifications> {
             NotificationsView(
                 navActionManager = navActionManager
             )
         }
 
-        composable(NavDestination.About.route()) {
+        composable<Route.About> {
             AboutView(
                 navActionManager = navActionManager
             )
         }
 
-        composable(NavDestination.Credits.route()) {
+        composable<Route.Credits> {
             CreditsView(
                 navActionManager = navActionManager
             )
         }
 
-        composable(
-            route = NavDestination.MediaDetails.route(),
-            arguments = NavDestination.MediaDetails.namedNavArguments
-        ) {
+        composable<Route.MediaDetails> {
             MediaDetailsView(
                 isLoggedIn = isLoggedIn,
                 navActionManager = navActionManager
             )
         }
 
-        composable(
-            route = NavDestination.FullPoster.route(),
-            arguments = NavDestination.FullPoster.namedNavArguments
-        ) { navEntry ->
+        composable<Route.FullPoster> {
+            val args = rememberNavArgsOf()
+
             FullPosterView(
-                pictures = navEntry.arguments?.getStringArray(NavArgument.Pictures.name)
-                    ?: emptyArray(),
+                pictures = args?.pictures ?: emptyList(),
                 navActionManager = navActionManager
             )
         }
 
-        composable(NavDestination.Profile.route()) {
+        composable<Route.Profile> {
             if (!isLoggedIn) {
                 DefaultScaffoldWithTopAppBar(
                     title = stringResource(R.string.title_profile),
@@ -238,7 +221,7 @@ fun MainNavigation(
             }
         }
 
-        composable(NavDestination.Search.route()) {
+        composable<Route.Search> {
             SearchHostView(
                 isCompactScreen = isCompactScreen,
                 padding = if (isCompactScreen) PaddingValues() else padding,

--- a/app/src/main/java/com/axiel7/moelist/ui/main/composables/MainNavigationRail.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/main/composables/MainNavigationRail.kt
@@ -21,7 +21,8 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import com.axiel7.moelist.R
 import com.axiel7.moelist.ui.base.BottomDestination
 import com.axiel7.moelist.ui.base.BottomDestination.Companion.Icon
-import com.axiel7.moelist.ui.base.navigation.NavDestination
+import com.axiel7.moelist.ui.base.navigation.Route
+import com.uragiristereo.serializednavigationextension.runtime.navigate
 
 @Composable
 fun MainNavigationRail(
@@ -34,7 +35,7 @@ fun MainNavigationRail(
             FloatingActionButton(
                 onClick = {
                     onItemSelected(-1)
-                    navController.navigate(NavDestination.Search.route()) {
+                    navController.navigate(Route.Search) {
                         popUpTo(navController.graph.findStartDestination().id) {
                             saveState = true
                         }

--- a/app/src/main/java/com/axiel7/moelist/ui/main/composables/MainTopAppBar.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/main/composables/MainTopAppBar.kt
@@ -33,7 +33,8 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import coil.compose.AsyncImage
 import com.axiel7.moelist.R
 import com.axiel7.moelist.ui.base.BottomDestination
-import com.axiel7.moelist.ui.base.navigation.NavDestination
+import com.axiel7.moelist.ui.base.navigation.Route
+import com.uragiristereo.serializednavigationextension.runtime.navigate
 
 @Composable
 fun MainTopAppBar(
@@ -62,7 +63,7 @@ fun MainTopAppBar(
         exit = slideOutVertically(targetOffsetY = { -it })
     ) {
         Card(
-            onClick = { navController.navigate(NavDestination.Search.route()) },
+            onClick = { navController.navigate(Route.Search) },
             modifier = modifier
                 .statusBarsPadding()
                 .fillMaxWidth()
@@ -98,7 +99,7 @@ fun MainTopAppBar(
                     modifier = Modifier
                         .clip(RoundedCornerShape(100))
                         .size(32.dp)
-                        .clickable { navController.navigate(NavDestination.Profile.route()) }
+                        .clickable { navController.navigate(Route.Profile) }
                 )
             }
         }//:Card

--- a/app/src/main/java/com/axiel7/moelist/ui/ranking/MediaRankingViewModel.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/ranking/MediaRankingViewModel.kt
@@ -6,8 +6,9 @@ import com.axiel7.moelist.data.model.media.MediaType
 import com.axiel7.moelist.data.model.media.RankingType
 import com.axiel7.moelist.data.repository.AnimeRepository
 import com.axiel7.moelist.data.repository.MangaRepository
-import com.axiel7.moelist.ui.base.navigation.NavArgument
+import com.axiel7.moelist.ui.base.navigation.Route
 import com.axiel7.moelist.ui.base.viewmodel.BaseViewModel
+import com.uragiristereo.serializednavigationextension.runtime.navArgsFlowOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -26,10 +27,9 @@ class MediaRankingViewModel(
     private val mangaRepository: MangaRepository,
 ) : BaseViewModel<MediaRankingUiState>(), MediaRankingEvent {
 
-    private val mediaType = savedStateHandle
-        .getStateFlow<String?>(NavArgument.MediaType.name, null)
+    private val mediaType = savedStateHandle.navArgsFlowOf<Route.MediaRanking>()
+        .map { it?.mediaType }
         .filterNotNull()
-        .map { MediaType.valueOf(it) }
 
     override val mutableUiState = MutableStateFlow(MediaRankingUiState(rankingType))
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { setUrl("https://www.jitpack.io") }
     }
 }
 rootProject.name = "MoeList"


### PR DESCRIPTION
As the title said. I'm integrating my [Serialized Navigation Extension](https://github.com/uragiristereo/serialized-navigation-extension) into the project. The reasons are simple, to eliminate the boilerplate setup with the official navigation library and achieve more type safety while keeping the signature of the official navigation library.

The library is still in alpha stage but I believe it works well already, just need to add documentations before releasing it as stable `v1.0.0`.

Contribution approval: [Discord | android-dev channel](https://discord.com/channels/741059285122940928/1112274456019226695/1195600252183519243)

Summary of changes:
- [x] Added the required dependencies.
- [x] Set up the routes.
- [x] Updated the navigation usages.

Tested with both debug and release builds.

https://github.com/axiel7/MoeList/assets/52477630/21a5a1b2-e255-4aea-be8f-52c06527610f

What's left that needs to improve later:
- Release the library `v1.0.0` and change the version in the Gradle script.
- Remove the `NavActionManager` class as the library provide a better API.
