### PR TITLE
Fix: Selected year on season chart now has scroll state

### DIFF
--- a/app/src/main/java/com/axiel7/moelist/ui/season/composables/SeasonChartFilterSheet.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/season/composables/SeasonChartFilterSheet.kt
@@ -51,13 +51,12 @@ fun SeasonChartFilterSheet(
     sheetState: SheetState,
     bottomPadding: Dp = 0.dp
 ) {
-
     val scrollState = rememberLazyListState()
 
-    LaunchedEffect(key1 = true) {
-        scrollState.scrollToItem(SeasonChartUiState.years.indexOf(uiState.season.year))
+    LaunchedEffect(sheetState.isVisible) {
+        val index = SeasonChartUiState.years.indexOf(uiState.season.year)
+        if (index != -1) scrollState.scrollToItem(index)
     }
-
 
     ModalBottomSheet(
         sheetState = sheetState,

--- a/app/src/main/java/com/axiel7/moelist/ui/season/composables/SeasonChartFilterSheet.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/season/composables/SeasonChartFilterSheet.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -23,6 +24,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -49,6 +51,14 @@ fun SeasonChartFilterSheet(
     sheetState: SheetState,
     bottomPadding: Dp = 0.dp
 ) {
+
+    val scrollState = rememberLazyListState()
+
+    LaunchedEffect(key1 = true) {
+        scrollState.scrollToItem(SeasonChartUiState.years.indexOf(uiState.season.year))
+    }
+
+
     ModalBottomSheet(
         sheetState = sheetState,
         onDismissRequest = onDismiss,
@@ -115,7 +125,8 @@ fun SeasonChartFilterSheet(
             }
 
             LazyRow(
-                contentPadding = PaddingValues(horizontal = 8.dp)
+                contentPadding = PaddingValues(horizontal = 8.dp),
+                state = scrollState
             ) {
                 items(SeasonChartUiState.years) {
                     FilterChip(


### PR DESCRIPTION
I fixed the issue that when user selects the year and then close the bottom sheet, scroll state of the selected year turn back to the default one. When there is `scrollState`, user can see selected year value immediately.