### PR TITLE
Introduce search history feature

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.serialization")
+    id("com.google.devtools.ksp")
 }
 
 android.buildFeatures.buildConfig = true
@@ -80,6 +81,9 @@ android {
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.12"
+    }
+    ksp {
+        arg("room.schemaLocation", "$projectDir/schemas")
     }
     packaging {
         resources {
@@ -158,4 +162,10 @@ dependencies {
     val serializedNavigationVersion = "e23f84fc1f" // TODO: use proper versioning once the library is released
     implementation("com.github.uragiristereo.serialized-navigation-extension:navigation-compose:$serializedNavigationVersion")
     implementation("com.github.uragiristereo.serialized-navigation-extension:serializer-kotlinx:$serializedNavigationVersion")
+
+    //Room
+    val roomVersion = "2.6.1"
+    implementation("androidx.room:room-runtime:$roomVersion")
+    implementation("androidx.room:room-ktx:$roomVersion")
+    ksp("androidx.room:room-compiler:$roomVersion")
 }

--- a/app/schemas/com.axiel7.moelist.data.local.MoeListDatabase/1.json
+++ b/app/schemas/com.axiel7.moelist.data.local.MoeListDatabase/1.json
@@ -1,0 +1,40 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "bdd220d277ea1849ad977d01755e1c2f",
+    "entities": [
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyword` TEXT NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`keyword`))",
+        "fields": [
+          {
+            "fieldPath": "keyword",
+            "columnName": "keyword",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyword"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bdd220d277ea1849ad977d01755e1c2f')"
+    ]
+  }
+}

--- a/app/src/main/java/com/axiel7/moelist/App.kt
+++ b/app/src/main/java/com/axiel7/moelist/App.kt
@@ -10,6 +10,7 @@ import coil3.memory.MemoryCache
 import coil3.request.crossfade
 import com.axiel7.moelist.data.model.media.TitleLanguage
 import com.axiel7.moelist.di.dataStoreModule
+import com.axiel7.moelist.di.databaseModule
 import com.axiel7.moelist.di.networkModule
 import com.axiel7.moelist.di.repositoryModule
 import com.axiel7.moelist.di.viewModelModule
@@ -35,7 +36,14 @@ class App : Application(), KoinComponent, SingletonImageLoader.Factory {
             }
             androidContext(this@App)
             workManagerFactory()
-            modules(networkModule, dataStoreModule, repositoryModule, viewModelModule, workerModule)
+            modules(
+                networkModule,
+                dataStoreModule,
+                repositoryModule,
+                viewModelModule,
+                workerModule,
+                databaseModule,
+            )
         }
     }
 

--- a/app/src/main/java/com/axiel7/moelist/data/local/DatabaseConverters.kt
+++ b/app/src/main/java/com/axiel7/moelist/data/local/DatabaseConverters.kt
@@ -1,0 +1,24 @@
+package com.axiel7.moelist.data.local
+
+import androidx.room.TypeConverter
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+object DatabaseConverters {
+    @TypeConverter
+    fun timestampToLocalDateTime(value: Long?): LocalDateTime? {
+        return value?.let {
+            Instant.ofEpochMilli(it)
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime()
+        }
+    }
+
+    @TypeConverter
+    fun localDateTimeToTimestamp(value: LocalDateTime?): Long? {
+        return value
+            ?.atZone(ZoneId.systemDefault())
+            ?.toEpochSecond()
+    }
+}

--- a/app/src/main/java/com/axiel7/moelist/data/local/MoeListDatabase.kt
+++ b/app/src/main/java/com/axiel7/moelist/data/local/MoeListDatabase.kt
@@ -1,0 +1,18 @@
+package com.axiel7.moelist.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.axiel7.moelist.data.local.searchhistory.SearchHistoryDao
+import com.axiel7.moelist.data.local.searchhistory.SearchHistoryEntity
+
+@Database(
+    entities = [
+        SearchHistoryEntity::class,
+    ],
+    version = 1,
+)
+@TypeConverters(DatabaseConverters::class)
+abstract class MoeListDatabase : RoomDatabase() {
+    abstract fun searchHistoryDao() : SearchHistoryDao
+}

--- a/app/src/main/java/com/axiel7/moelist/data/local/searchhistory/SearchHistoryDao.kt
+++ b/app/src/main/java/com/axiel7/moelist/data/local/searchhistory/SearchHistoryDao.kt
@@ -1,0 +1,19 @@
+package com.axiel7.moelist.data.local.searchhistory
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SearchHistoryDao {
+    @Query("select * from search_history order by updated_at DESC limit 10")
+    fun getItems(): Flow<List<SearchHistoryEntity>>
+
+    @Upsert
+    suspend fun addItem(item: SearchHistoryEntity)
+
+    @Delete
+    suspend fun deleteItem(item: SearchHistoryEntity)
+}

--- a/app/src/main/java/com/axiel7/moelist/data/local/searchhistory/SearchHistoryEntity.kt
+++ b/app/src/main/java/com/axiel7/moelist/data/local/searchhistory/SearchHistoryEntity.kt
@@ -1,0 +1,16 @@
+package com.axiel7.moelist.data.local.searchhistory
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.time.LocalDateTime
+
+@Entity(tableName = "search_history")
+data class SearchHistoryEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "keyword")
+    val keyword: String,
+
+    @ColumnInfo(name = "updated_at")
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/app/src/main/java/com/axiel7/moelist/data/local/searchhistory/SearchHistoryMapper.kt
+++ b/app/src/main/java/com/axiel7/moelist/data/local/searchhistory/SearchHistoryMapper.kt
@@ -1,0 +1,25 @@
+package com.axiel7.moelist.data.local.searchhistory
+
+import com.axiel7.moelist.data.model.SearchHistory
+
+fun SearchHistoryEntity.toSearchHistory(): SearchHistory {
+    return SearchHistory(
+        keyword = keyword,
+        updatedAt = updatedAt,
+    )
+}
+
+fun SearchHistory.toSearchEntity(): SearchHistoryEntity {
+    return SearchHistoryEntity(
+        keyword = keyword,
+        updatedAt = updatedAt,
+    )
+}
+
+fun List<SearchHistoryEntity>.toSearchHistoryList(): List<SearchHistory> {
+    return map(SearchHistoryEntity::toSearchHistory)
+}
+
+fun List<SearchHistory>.toSearchHistoryEntityList(): List<SearchHistoryEntity> {
+    return map(SearchHistory::toSearchEntity)
+}

--- a/app/src/main/java/com/axiel7/moelist/data/model/SearchHistory.kt
+++ b/app/src/main/java/com/axiel7/moelist/data/model/SearchHistory.kt
@@ -1,0 +1,8 @@
+package com.axiel7.moelist.data.model
+
+import java.time.LocalDateTime
+
+data class SearchHistory(
+    val keyword: String,
+    val updatedAt: LocalDateTime,
+)

--- a/app/src/main/java/com/axiel7/moelist/data/repository/SearchHistoryRepository.kt
+++ b/app/src/main/java/com/axiel7/moelist/data/repository/SearchHistoryRepository.kt
@@ -1,0 +1,29 @@
+package com.axiel7.moelist.data.repository
+
+import com.axiel7.moelist.data.local.searchhistory.SearchHistoryDao
+import com.axiel7.moelist.data.local.searchhistory.SearchHistoryEntity
+import com.axiel7.moelist.data.local.searchhistory.toSearchEntity
+import com.axiel7.moelist.data.local.searchhistory.toSearchHistoryList
+import com.axiel7.moelist.data.model.SearchHistory
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class SearchHistoryRepository(
+    private val dao: SearchHistoryDao,
+) {
+    fun getItems(): Flow<List<SearchHistory>> {
+        return dao.getItems().map(List<SearchHistoryEntity>::toSearchHistoryList)
+    }
+
+    suspend fun addItem(query: String) {
+        val trimmedQuery = query.trim()
+
+        if (trimmedQuery.isNotBlank()) {
+            dao.addItem(SearchHistoryEntity(keyword = trimmedQuery))
+        }
+    }
+
+    suspend fun deleteItem(item: SearchHistory) {
+        dao.deleteItem(item.toSearchEntity())
+    }
+}

--- a/app/src/main/java/com/axiel7/moelist/di/DatabaseModule.kt
+++ b/app/src/main/java/com/axiel7/moelist/di/DatabaseModule.kt
@@ -1,0 +1,27 @@
+package com.axiel7.moelist.di
+
+import android.content.Context
+import androidx.room.Room
+import com.axiel7.moelist.data.local.MoeListDatabase
+import com.axiel7.moelist.data.local.searchhistory.SearchHistoryDao
+import com.axiel7.moelist.data.repository.SearchHistoryRepository
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.module
+
+val databaseModule = module {
+    single<MoeListDatabase> { provideDatabase(androidContext()) }
+    single<SearchHistoryDao> { get<MoeListDatabase>().searchHistoryDao() }
+
+    singleOf(::SearchHistoryRepository)
+}
+
+private fun provideDatabase(context: Context): MoeListDatabase {
+    return Room
+        .databaseBuilder(
+            context = context,
+            klass = MoeListDatabase::class.java,
+            name = "moelist-database",
+        )
+        .build()
+}

--- a/app/src/main/java/com/axiel7/moelist/ui/search/SearchEvent.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/search/SearchEvent.kt
@@ -1,9 +1,12 @@
 package com.axiel7.moelist.ui.search
 
+import com.axiel7.moelist.data.model.SearchHistory
 import com.axiel7.moelist.data.model.media.MediaType
 import com.axiel7.moelist.ui.base.event.PagedUiEvent
 
 interface SearchEvent : PagedUiEvent {
     fun search(query: String)
     fun onChangeMediaType(value: MediaType)
+    fun onSaveSearchHistory(query: String)
+    fun onRemoveSearchHistory(item: SearchHistory)
 }

--- a/app/src/main/java/com/axiel7/moelist/ui/search/SearchUiState.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/search/SearchUiState.kt
@@ -3,6 +3,7 @@ package com.axiel7.moelist.ui.search
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
+import com.axiel7.moelist.data.model.SearchHistory
 import com.axiel7.moelist.data.model.media.BaseMediaList
 import com.axiel7.moelist.data.model.media.MediaType
 import com.axiel7.moelist.ui.base.state.PagedUiState
@@ -12,6 +13,7 @@ data class SearchUiState(
     val query: String = "",
     val mediaType: MediaType = MediaType.ANIME,
     val mediaList: SnapshotStateList<BaseMediaList> = mutableStateListOf(),
+    val searchHistoryList: List<SearchHistory> = emptyList(),
     val performSearch: Boolean = false,
     val noResults: Boolean = false,
     override val nextPage: String? = null,

--- a/app/src/main/res/drawable/ic_history_24.xml
+++ b/app/src/main/res/drawable/ic_history_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M480,840q-138,0 -240.5,-91.5T122,520h82q14,104 92.5,172T480,760q117,0 198.5,-81.5T760,480q0,-117 -81.5,-198.5T480,200q-69,0 -129,32t-101,88h110v80L120,400v-240h80v94q51,-64 124.5,-99T480,120q75,0 140.5,28.5t114,77q48.5,48.5 77,114T840,480q0,75 -28.5,140.5t-77,114q-48.5,48.5 -114,77T480,840ZM592,648L440,496v-216h80v184l128,128 -56,56Z"
+      android:fillColor="#000000"/>
+</vector>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     id("com.android.application") version "8.4.0" apply false
     id("org.jetbrains.kotlin.android") version kotlinVersion apply false
     id("org.jetbrains.kotlin.plugin.serialization") version kotlinVersion apply false
+    id("com.google.devtools.ksp") version "1.9.23-1.0.20" apply false
 }


### PR DESCRIPTION
![image](https://github.com/axiel7/MoeList/assets/52477630/98047e76-bd93-4ee7-b49c-51a4620afc47)

### Summary
- Using the [Room](https://developer.android.com/training/data-storage/room) library to store the search history locally into the device.
- Every time the search query is being performed, it will also save the keyword and the time into the database. If the keyword is already saved inside the database, it will simply update the time.
- Maximum of 10 recently searched keywords would be shown into the list.
- Clicking the item would perform a search query of that item, and long pressing it will delete the item.

### Things that need to improve in future versions
- Deleting the item with a swipe gesture or a confirmation to delete.
- Also query the database for items that contains the current keyword when user is typing (autocomplete-like feature).
- Maybe instead of the queries that are saved, how about save the anime or manga that has been recently clicked when searching.

### Result

https://github.com/axiel7/MoeList/assets/52477630/8ee96150-ccdb-4961-84b6-a083d8261e40


