### PR TITLE
MoeList-3.7.1 make seasonView_2perRow_like_malApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,21 +67,22 @@ Want an AniList version? Check [AniHyou](https://github.com/axiel7/AniHyou-andro
 * [Coil](https://github.com/coil-kt/coil)
 
 # Building
-Put the following in a new ./private.properties file:
 
-```properties
-CLIENT_ID="your_mal_api_client_id"
-```
+1) Put the following in a new ./private.properties file:
 
-To get a Client ID, go to the [API panel](https://myanimelist.net/apiconfig) and create a new app with *App Type* set to `android` and *Redirect URL* set to `moelist://moelist.page.link/`
+   ```properties
+   CLIENT_ID="your_mal_api_client_id"
+   ```
 
-_2_
-put this in App/build.gradle.Kts
-```properties
-val properties = Properties()                                              
-properties.load(project.rootProject.file("local.properties").reader())
-properties.load(project.rootProject.file("private.properties").reader())       //add this line..
-```
+   To get a Client ID, go to the [API panel](https://myanimelist.net/apiconfig) and create a new app with *App Type* set to `android` and *Redirect URL* set to `moelist://moelist.page.link/`
+
+2) put this in App/build.gradle.Kts : 
+
+   ```properties
+   val properties = Properties()                                              
+   properties.load(project.rootProject.file("local.properties").reader())
+   properties.load(project.rootProject.file("private.properties").reader())       //add this line..
+   ```
 
 # Donate 💸
 Support the development of MoeList by making a donation via:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ CLIENT_ID="your_mal_api_client_id"
 
 To get a Client ID, go to the [API panel](https://myanimelist.net/apiconfig) and create a new app with *App Type* set to `android` and *Redirect URL* set to `moelist://moelist.page.link/`
 
+_2_
+put this in App/build.gradle.Kts
+```properties
+val properties = Properties()                                              
+properties.load(project.rootProject.file("local.properties").reader())
+properties.load(project.rootProject.file("private.properties").reader())       //add this line..
+```
+
 # Donate 💸
 Support the development of MoeList by making a donation via:
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,15 +9,17 @@ plugins {
 }
 
 val properties = Properties()
+properties.load(project.rootProject.file("local.properties").reader())
+
 properties.load(project.rootProject.file("private.properties").reader())
 
 android {
-    compileSdk = 35
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.axiel7.moelist"
         minSdk = 23
-        targetSdk = 35
+        targetSdk = 34
         versionCode = 146
         versionName = "3.7.1"
         setProperty("archivesBaseName", "moelist-v$versionName")
@@ -34,6 +36,8 @@ android {
 
     buildTypes {
         debug {
+            resValue("string", "app_name", "Moelist debug")
+
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-DEBUG"
             isDebuggable = true
@@ -95,7 +99,7 @@ dependencies {
 
     implementation("androidx.browser:browser:1.8.0")
     implementation("androidx.datastore:datastore-preferences:1.1.1")
-    implementation("androidx.work:work-runtime:2.9.1")
+    implementation("androidx.work:work-runtime:2.9.0")
     implementation("androidx.core:core-splashscreen:1.0.1")
 
     //Compose
@@ -104,14 +108,14 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     debugImplementation("androidx.compose.ui:ui-tooling")
 
-    val materialVersion = "1.3.0-beta05"
+    val materialVersion = "1.3.0-beta04"
     implementation("androidx.compose.material3:material3-android:$materialVersion")
     implementation("androidx.compose.material3:material3-window-size-class:$materialVersion")
 
-    implementation("androidx.activity:activity-compose:1.9.1")
-    implementation("androidx.navigation:navigation-compose:2.8.0-beta07")
+    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation("androidx.navigation:navigation-compose:2.8.0-beta05")
 
-    val lifecycleVersion = "2.8.4"
+    val lifecycleVersion = "2.8.3"
     implementation("androidx.lifecycle:lifecycle-runtime-compose:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:$lifecycleVersion")
 
@@ -143,7 +147,7 @@ dependencies {
     implementation("org.apache.commons:commons-text:1.12.0")
 
     //Image
-    val coilVersion = "3.0.0-alpha10"
+    val coilVersion = "3.0.0-alpha08"
     implementation("io.coil-kt.coil3:coil-compose:$coilVersion")
     implementation("io.coil-kt.coil3:coil-network-okhttp:$coilVersion")
 

--- a/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaItemVertical_2perRow.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaItemVertical_2perRow.kt
@@ -1,0 +1,192 @@
+package com.axiel7.moelist.ui.composables.media
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.axiel7.moelist.R
+import com.axiel7.moelist.ui.composables.TextIconHorizontal
+import com.axiel7.moelist.ui.composables.defaultPlaceholder
+import com.axiel7.moelist.ui.composables.score.SmallScoreIndicator
+import com.axiel7.moelist.ui.theme.MoeListTheme
+import com.axiel7.moelist.utils.NumExtensions.format
+
+//MAL app style. its easier to see poster on phoneScreen.
+
+//consts for 2perRow
+const val multi =1.7;
+const val MEDIA_POSTER_COMPACT_HEIGHT_2pr = 100*multi
+const val MEDIA_POSTER_COMPACT_WIDTH_2pr = 100*multi
+
+const val MEDIA_POSTER_SMALL_HEIGHT_2pr = 140*multi
+const val MEDIA_POSTER_SMALL_WIDTH_2pr = 100*multi
+
+const val MEDIA_POSTER_MEDIUM_HEIGHT_2pr = 156*multi
+const val MEDIA_POSTER_MEDIUM_WIDTH_2pr = 110*multi
+
+const val MEDIA_POSTER_BIG_HEIGHT_2pr = 213*multi
+const val MEDIA_POSTER_BIG_WIDTH_2pr = 150*multi
+
+const val MEDIA_ITEM_VERTICAL_HEIGHT_2pr = 200*multi
+
+
+
+@Composable
+fun MediaItemVertical_2perRow(
+    title: String,
+    imageUrl: String?,
+    modifier: Modifier = Modifier,
+    subtitle: @Composable (() -> Unit)? = null,
+    subtitle2: @Composable (() -> Unit)? = null,
+    minLines: Int = 1,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .width(MEDIA_POSTER_SMALL_WIDTH_2pr.dp)
+            //.width(300.dp)
+            .sizeIn(
+                minHeight = MEDIA_ITEM_VERTICAL_HEIGHT_2pr.dp -100.dp
+            )
+            .clip(RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+
+        /*use box to overlay*/
+        //val shape =  RoundedCornerShape(8.dp)
+        Box(
+            modifier = modifier
+                //.background(Color.Red )
+                .fillMaxWidth(),
+            contentAlignment = Alignment.BottomStart
+        )
+        {
+            //layer1
+            MediaPoster(
+                url = imageUrl,
+                modifier = Modifier
+                    .size(
+                        width = MEDIA_POSTER_MEDIUM_WIDTH_2pr.dp ,
+                        height = MEDIA_POSTER_MEDIUM_HEIGHT_2pr.dp
+                    )
+            )
+            //layer2
+            Column(
+                modifier = modifier
+                    .offset(x=5.dp ,y= -14.dp)
+                    .background(Color.DarkGray)
+            )
+            {
+                subtitle?.let { it() }
+                subtitle2?.let { it() }
+            }
+
+        }
+
+
+        Text(
+            text = title,
+            modifier = Modifier
+                .width(MEDIA_POSTER_SMALL_WIDTH_2pr.dp)
+                .padding(top = 2.dp, bottom = 4.dp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 15.sp,
+            lineHeight = 18.sp,
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 2,
+            minLines = minLines
+        )
+
+
+    }
+}
+
+
+
+@Composable
+fun MediaItemVertical_2perRowPlaceholder(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .size(
+                width = (MEDIA_POSTER_SMALL_WIDTH_2pr + 8).dp,
+                height = MEDIA_ITEM_VERTICAL_HEIGHT_2pr.dp
+            )
+            .padding(end = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = Modifier
+                .size(
+                    width = MEDIA_POSTER_SMALL_WIDTH_2pr.dp,
+                    height = MEDIA_POSTER_SMALL_HEIGHT_2pr.dp
+                )
+                .defaultPlaceholder(visible = true)
+        )
+
+        Text(
+            text = "This is a placeholder",
+            modifier = Modifier
+                .padding(top = 8.dp)
+                .defaultPlaceholder(visible = true),
+            fontSize = 15.sp,
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 2
+        )
+    }
+}
+
+@Preview
+@Composable
+fun MediaItemVertical_2perRowPreview() {
+    MoeListTheme {
+        Surface {
+            val _textColor = Color(200,200,200);
+
+            MediaItemVertical_2perRow (
+                imageUrl = null,
+                title = "This is a very large anime title that should serve as a preview example",
+                subtitle = {
+                    SmallScoreIndicator(
+                        score = 8.34f,
+                        fontSize = 14.sp,
+                        textColor = _textColor,
+                    )
+                },
+                subtitle2 = {
+                        TextIconHorizontal(
+                            text = "222.123",
+                            icon = R.drawable.ic_round_group_24,
+                            color = _textColor,
+                            fontSize = 13.sp,
+                            iconSize = 16.dp
+                        )
+                },
+                onClick = {}
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaPoster.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaPoster.kt
@@ -27,6 +27,7 @@ const val MEDIA_POSTER_MEDIUM_WIDTH = 110
 const val MEDIA_POSTER_BIG_HEIGHT = 213
 const val MEDIA_POSTER_BIG_WIDTH = 150
 
+
 @Composable
 fun MediaPoster(
     url: String?,

--- a/app/src/main/java/com/axiel7/moelist/ui/composables/score/ScoreIndicator.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/composables/score/ScoreIndicator.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -23,7 +24,10 @@ fun SmallScoreIndicator(
     score: Float?,
     modifier: Modifier = Modifier,
     fontSize: TextUnit = 14.sp,
-) {
+    textColor: Color = MaterialTheme.colorScheme.outline,
+    ) {
+
+
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically
@@ -31,12 +35,12 @@ fun SmallScoreIndicator(
         Icon(
             painter = painterResource(R.drawable.ic_round_star_16),
             contentDescription = stringResource(R.string.mean_score),
-            tint = MaterialTheme.colorScheme.outline
+            tint = textColor
         )
         Text(
             text = score.toStringPositiveValueOrUnknown(),
             modifier = Modifier.padding(horizontal = 4.dp),
-            color = MaterialTheme.colorScheme.outline,
+            color = textColor,
             fontSize = fontSize
         )
     }

--- a/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -44,8 +45,11 @@ import com.axiel7.moelist.ui.base.navigation.NavActionManager
 import com.axiel7.moelist.ui.composables.DefaultScaffoldWithTopAppBar
 import com.axiel7.moelist.ui.composables.TextIconHorizontal
 import com.axiel7.moelist.ui.composables.media.MEDIA_POSTER_SMALL_WIDTH
+import com.axiel7.moelist.ui.composables.media.MEDIA_POSTER_SMALL_WIDTH_2pr
 import com.axiel7.moelist.ui.composables.media.MediaItemDetailedPlaceholder
 import com.axiel7.moelist.ui.composables.media.MediaItemVertical
+import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRow
+import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRowPlaceholder
 import com.axiel7.moelist.ui.composables.score.SmallScoreIndicator
 import com.axiel7.moelist.ui.season.composables.SeasonChartFilterSheet
 import com.axiel7.moelist.ui.theme.MoeListTheme
@@ -53,6 +57,10 @@ import com.axiel7.moelist.utils.ContextExtensions.showToast
 import com.axiel7.moelist.utils.NumExtensions.format
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
+
+//val Teal200 = Color(0xFF03DAC5)
+val _textColor = Color(200, 200, 200);
+
 
 @Composable
 fun SeasonChartView(
@@ -125,18 +133,19 @@ private fun SeasonChartViewContent(
             .only(WindowInsetsSides.Horizontal)
     ) { padding ->
         LazyVerticalGrid(
-            columns = GridCells.Adaptive(minSize = MEDIA_POSTER_SMALL_WIDTH.dp),
+            //columns = GridCells.Adaptive(minSize = MEDIA_POSTER_SMALL_WIDTH_2pr.dp),
+            columns = GridCells.Fixed(2),
             modifier = Modifier
                 .padding(padding)
                 .fillMaxSize(),
             contentPadding = PaddingValues(
-                start = 8.dp,
+                start = 2.dp,
                 top = 8.dp,
-                end = 8.dp,
+                end = 2.dp,
                 bottom = bottomBarPadding
             ),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterHorizontally)
         ) {
             items(
                 items = uiState.animes,
@@ -147,13 +156,16 @@ private fun SeasonChartViewContent(
                     modifier = Modifier.fillMaxWidth(),
                     contentAlignment = Alignment.TopCenter
                 ) {
-                    MediaItemVertical(
+//                    val _textColor = Color(200,200,200);
+
+                    MediaItemVertical_2perRow(
                         imageUrl = item.node.mainPicture?.large,
                         title = item.node.userPreferredTitle(),
                         subtitle = {
                             SmallScoreIndicator(
                                 score = item.node.mean,
-                                fontSize = 13.sp
+                                fontSize = 13.sp,
+                                textColor = _textColor,
                             )
                         },
                         subtitle2 = {
@@ -161,7 +173,7 @@ private fun SeasonChartViewContent(
                                 TextIconHorizontal(
                                     text = users,
                                     icon = R.drawable.ic_round_group_24,
-                                    color = MaterialTheme.colorScheme.outline,
+                                    color = _textColor,
                                     fontSize = 13.sp,
                                     iconSize = 16.dp
                                 )
@@ -175,8 +187,9 @@ private fun SeasonChartViewContent(
                 }
             }
             if (uiState.isLoading) {
-                items(12) {
-                    MediaItemDetailedPlaceholder()
+                items(11) {
+                    MediaItemVertical_2perRowPlaceholder()
+                    //MediaItemDetailedPlaceholder()
                 }
             }
             item(contentType = { 0 }) {


### PR DESCRIPTION
currently i switch back to forth between Official MapApp and Moelist.

 due to Moelist  SeasonView   images being too small.  
 
SeasonView is  The Most important  Page For Casual Anime Fans.
big photos are really helpful, when discovering new animes .
  
 so i wanted to bring it over here.





|  mal app official |  moelist 3 .7.1 patched  |  -       |
| ------------- | ------------- |------------- |
|      ![ss-mal-450px](https://github.com/user-attachments/assets/fa770f86-5cea-4714-afc6-3d028d18f210)       |   ![Screenshot_moe_lowq](https://github.com/user-attachments/assets/e03cf2c7-a887-47a3-8a1d-03173ab265e8)  | ![firefox_IMHuJr4SAI](https://github.com/user-attachments/assets/0a7e4b94-3626-4925-a190-c73f31e21ff8)  |

 