### PR TITLE
  make seasonView 2perRow like malApp

### DIFF
--- a/app/src/main/java/com/axiel7/moelist/ui/composables/TextIcon.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/composables/TextIcon.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
@@ -36,6 +37,7 @@ fun TextIconHorizontal(
     color: Color = MaterialTheme.colorScheme.onSurfaceVariant,
     fontSize: TextUnit = TextUnit.Unspecified,
     iconSize: Dp = 24.dp,
+    lineHeight: TextUnit = TextUnit.Unspecified,
 ) {
     Row(
         modifier = modifier,
@@ -53,10 +55,25 @@ fun TextIconHorizontal(
             text = text,
             modifier = Modifier.padding(horizontal = 4.dp),
             color = color,
-            fontSize = fontSize
+            fontSize = fontSize,
+            lineHeight = lineHeight,
+
         )
     }
 }
+
+@Preview(showBackground = true)
+@Composable
+fun TextIconHorizontalPreview() {
+    MoeListTheme {
+        TextIconHorizontal(text = "This is an example", icon = R.drawable.ic_round_details_star_24)
+    }
+}
+
+
+
+
+
 
 @Composable
 fun TextIconVertical(
@@ -118,13 +135,6 @@ fun TextIconVertical(
     }
 }
 
-@Preview(showBackground = true)
-@Composable
-fun TextIconHorizontalPreview() {
-    MoeListTheme {
-        TextIconHorizontal(text = "This is an example", icon = R.drawable.ic_round_details_star_24)
-    }
-}
 
 @Preview(showBackground = true)
 @Composable

--- a/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaItemVertical_2perRow.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaItemVertical_2perRow.kt
@@ -1,0 +1,192 @@
+package com.axiel7.moelist.ui.composables.media
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.axiel7.moelist.R
+import com.axiel7.moelist.ui.composables.TextIconHorizontal
+import com.axiel7.moelist.ui.composables.defaultPlaceholder
+import com.axiel7.moelist.ui.composables.score.SmallScoreIndicator
+import com.axiel7.moelist.ui.theme.MoeListTheme
+import com.axiel7.moelist.utils.NumExtensions.format
+
+//MAL app style. its easier to see poster on phoneScreen.
+
+//consts for 2perRow
+const val multi =1.7;
+const val MEDIA_POSTER_COMPACT_HEIGHT_2pr = 100*multi
+const val MEDIA_POSTER_COMPACT_WIDTH_2pr = 100*multi
+
+const val MEDIA_POSTER_SMALL_HEIGHT_2pr = 140*multi
+const val MEDIA_POSTER_SMALL_WIDTH_2pr = 100*multi
+
+const val MEDIA_POSTER_MEDIUM_HEIGHT_2pr = 156*multi
+const val MEDIA_POSTER_MEDIUM_WIDTH_2pr = 110*multi
+
+const val MEDIA_POSTER_BIG_HEIGHT_2pr = 213*multi
+const val MEDIA_POSTER_BIG_WIDTH_2pr = 150*multi
+
+const val MEDIA_ITEM_VERTICAL_HEIGHT_2pr = 200*multi
+
+
+
+@Composable
+fun MediaItemVertical_2perRow(
+    title: String,
+    imageUrl: String?,
+    modifier: Modifier = Modifier,
+    subtitle: @Composable (() -> Unit)? = null,
+    subtitle2: @Composable (() -> Unit)? = null,
+    minLines: Int = 1,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .width(MEDIA_POSTER_SMALL_WIDTH_2pr.dp)
+            //.width(300.dp)
+            .sizeIn(
+                minHeight = MEDIA_ITEM_VERTICAL_HEIGHT_2pr.dp -100.dp
+            )
+            .clip(RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+
+        /*use box to overlay*/
+        //val shape =  RoundedCornerShape(8.dp)
+        Box(
+            modifier = modifier
+                //.background(Color.Red )
+                .fillMaxWidth(),
+            contentAlignment = Alignment.BottomStart
+        )
+        {
+            //layer1
+            MediaPoster(
+                url = imageUrl,
+                modifier = Modifier
+                    .size(
+                        width = MEDIA_POSTER_MEDIUM_WIDTH_2pr.dp ,
+                        height = MEDIA_POSTER_MEDIUM_HEIGHT_2pr.dp
+                    )
+            )
+            //layer2
+            Column(
+                modifier = modifier
+                    .offset(x=5.dp ,y= -14.dp)
+                    .background(Color.DarkGray)
+            )
+            {
+                subtitle?.let { it() }
+                subtitle2?.let { it() }
+            }
+
+        }
+
+
+        Text(
+            text = title,
+            modifier = Modifier
+                .width(MEDIA_POSTER_SMALL_WIDTH_2pr.dp)
+                .padding(top = 2.dp, bottom = 4.dp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 15.sp,
+            lineHeight = 18.sp,
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 2,
+            minLines = minLines
+        )
+
+
+    }
+}
+
+
+
+@Composable
+fun MediaItemVertical_2perRowPlaceholder(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .size(
+                width = (MEDIA_POSTER_SMALL_WIDTH_2pr + 8).dp,
+                height = MEDIA_ITEM_VERTICAL_HEIGHT_2pr.dp
+            )
+            .padding(end = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = Modifier
+                .size(
+                    width = MEDIA_POSTER_SMALL_WIDTH_2pr.dp,
+                    height = MEDIA_POSTER_SMALL_HEIGHT_2pr.dp
+                )
+                .defaultPlaceholder(visible = true)
+        )
+
+        Text(
+            text = "This is a placeholder",
+            modifier = Modifier
+                .padding(top = 8.dp)
+                .defaultPlaceholder(visible = true),
+            fontSize = 15.sp,
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 2
+        )
+    }
+}
+
+@Preview
+@Composable
+fun MediaItemVertical_2perRowPreview() {
+    MoeListTheme {
+        Surface {
+            val _textColor = Color(200,200,200);
+
+            MediaItemVertical_2perRow (
+                imageUrl = null,
+                title = "This is a very large anime title that should serve as a preview example",
+                subtitle = {
+                    SmallScoreIndicator(
+                        score = 8.34f,
+                        fontSize = 14.sp,
+                        textColor = _textColor,
+                    )
+                },
+                subtitle2 = {
+                        TextIconHorizontal(
+                            text = "222.123",
+                            icon = R.drawable.ic_round_group_24,
+                            color = _textColor,
+                            fontSize = 13.sp,
+                            iconSize = 16.dp
+                        )
+                },
+                onClick = {}
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaItemVertical_2perRow.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaItemVertical_2perRow.kt
@@ -36,14 +36,13 @@ import com.axiel7.moelist.ui.composables.score.SmallScoreIndicator
 import com.axiel7.moelist.ui.theme.MoeListTheme
 import com.axiel7.moelist.utils.NumExtensions.format
 
-//MAL app style. its easier to see poster on phoneScreen.
-//const for 2perRow
-const val multi =1.7;
+//MAL app style. 2perRow - its easier to see poster on phoneScreen.
+const val multi =2.0;
 const val MEDIA_POSTER_COMPACT_HEIGHT_2pr = 100*multi
 const val MEDIA_POSTER_COMPACT_WIDTH_2pr = 100*multi
 
 const val MEDIA_POSTER_SMALL_HEIGHT_2pr = 140*multi
-const val MEDIA_POSTER_SMALL_WIDTH_2pr = 100*multi +0 //+100 for debug center img
+const val MEDIA_POSTER_SMALL_WIDTH_2pr = 100*multi  +20 //+100 see if img is centered
 
 const val MEDIA_POSTER_MEDIUM_HEIGHT_2pr = 156*multi
 const val MEDIA_POSTER_MEDIUM_WIDTH_2pr = 110*multi
@@ -60,11 +59,11 @@ val DarkTheme_textColor = Color(220, 220, 220)
 @Composable
 fun getGridCellFixed_Count_ForOrientation():Int
 {
-    var orient = LocalConfiguration.current.orientation
-    var landScape = Configuration.ORIENTATION_LANDSCAPE
+    val orient = LocalConfiguration.current.orientation
+    val landScape = Configuration.ORIENTATION_LANDSCAPE
 
-    val count = if(orient == landScape ) 3 else 2;
-    return  count;
+    val count = if(orient == landScape ) 3 else 2
+    return  count
 }
 
 
@@ -140,6 +139,7 @@ fun MediaItemVertical_2perRow(
 
 
 
+@Preview // for debug
 @Composable
 fun MediaItemVertical_2perRowPlaceholder(
     modifier: Modifier = Modifier
@@ -148,23 +148,27 @@ fun MediaItemVertical_2perRowPlaceholder(
     Column(
         modifier = modifier
             .size(
-                width = (MEDIA_POSTER_SMALL_WIDTH_2pr + 8).dp,
+                width = (MEDIA_POSTER_SMALL_WIDTH_2pr ).dp,
                 height = MEDIA_ITEM_VERTICAL_HEIGHT_2pr.dp
             )
-            .padding(end = 8.dp),
+            //.padding(end = 8.dp ),
+            .padding(start = 8.dp,end = 8.dp, top=4.dp ),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Box(
             modifier = Modifier
                 .size(
-                    width = MEDIA_POSTER_SMALL_WIDTH_2pr.dp,
-                    height = MEDIA_POSTER_SMALL_HEIGHT_2pr.dp
+//                    width = MEDIA_POSTER_SMALL_WIDTH_2pr.dp,
+//                    height = MEDIA_POSTER_SMALL_HEIGHT_2pr.dp +14.dp
+                    width = MEDIA_POSTER_MEDIUM_WIDTH_2pr.dp,
+                    height = MEDIA_POSTER_MEDIUM_HEIGHT_2pr.dp -6.dp
                 )
+                .padding( bottom=4.dp )
                 .defaultPlaceholder(visible = true)
         )
 
         Text(
-            text = "This is a placeholder",
+            text = "This is a placeholder - i need to make it 2 lines  ",
             modifier = Modifier
                 .padding(top = 8.dp)
                 .defaultPlaceholder(visible = true),

--- a/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaItemVertical_2perRow.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaItemVertical_2perRow.kt
@@ -1,7 +1,9 @@
 package com.axiel7.moelist.ui.composables.media
 
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContentPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
@@ -21,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -33,14 +37,13 @@ import com.axiel7.moelist.ui.theme.MoeListTheme
 import com.axiel7.moelist.utils.NumExtensions.format
 
 //MAL app style. its easier to see poster on phoneScreen.
-
-//consts for 2perRow
+//const for 2perRow
 const val multi =1.7;
 const val MEDIA_POSTER_COMPACT_HEIGHT_2pr = 100*multi
 const val MEDIA_POSTER_COMPACT_WIDTH_2pr = 100*multi
 
 const val MEDIA_POSTER_SMALL_HEIGHT_2pr = 140*multi
-const val MEDIA_POSTER_SMALL_WIDTH_2pr = 100*multi
+const val MEDIA_POSTER_SMALL_WIDTH_2pr = 100*multi +0 //+100 for debug center img
 
 const val MEDIA_POSTER_MEDIUM_HEIGHT_2pr = 156*multi
 const val MEDIA_POSTER_MEDIUM_WIDTH_2pr = 110*multi
@@ -48,8 +51,21 @@ const val MEDIA_POSTER_MEDIUM_WIDTH_2pr = 110*multi
 const val MEDIA_POSTER_BIG_HEIGHT_2pr = 213*multi
 const val MEDIA_POSTER_BIG_WIDTH_2pr = 150*multi
 
-const val MEDIA_ITEM_VERTICAL_HEIGHT_2pr = 200*multi
+const val MEDIA_ITEM_VERTICAL_HEIGHT_2pr = (156+25)*multi
 
+//val Teal200 = Color(0xFF03DAC5)
+val DarkTheme_textColor = Color(220, 220, 220)
+
+
+@Composable
+fun getGridCellFixed_Count_ForOrientation():Int
+{
+    var orient = LocalConfiguration.current.orientation
+    var landScape = Configuration.ORIENTATION_LANDSCAPE
+
+    val count = if(orient == landScape ) 3 else 2;
+    return  count;
+}
 
 
 @Composable
@@ -67,18 +83,15 @@ fun MediaItemVertical_2perRow(
             .width(MEDIA_POSTER_SMALL_WIDTH_2pr.dp)
             //.width(300.dp)
             .sizeIn(
-                minHeight = MEDIA_ITEM_VERTICAL_HEIGHT_2pr.dp -100.dp
+                minHeight = MEDIA_ITEM_VERTICAL_HEIGHT_2pr.dp // -100.dp
             )
             .clip(RoundedCornerShape(8.dp))
             .clickable(onClick = onClick),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-
-        /*use box to overlay*/
-        //val shape =  RoundedCornerShape(8.dp)
+        /*Poster And StartCount Container - use box to overlay*/
         Box(
             modifier = modifier
-                //.background(Color.Red )
                 .fillMaxWidth(),
             contentAlignment = Alignment.BottomStart
         )
@@ -88,15 +101,17 @@ fun MediaItemVertical_2perRow(
                 url = imageUrl,
                 modifier = Modifier
                     .size(
-                        width = MEDIA_POSTER_MEDIUM_WIDTH_2pr.dp ,
+                        width = MEDIA_POSTER_MEDIUM_WIDTH_2pr.dp  ,
                         height = MEDIA_POSTER_MEDIUM_HEIGHT_2pr.dp
-                    )
+                    ),
             )
-            //layer2
+            //layer2 - StartCount -PeopleCount
             Column(
                 modifier = modifier
-                    .offset(x=5.dp ,y= -14.dp)
+                    .offset(x=4.dp ,y= -15.dp)
                     .background(Color.DarkGray)
+                    .padding(vertical = 3.dp, horizontal = 0.dp),
+//                horizontalAlignment = Alignment.Start,
             )
             {
                 subtitle?.let { it() }
@@ -129,6 +144,7 @@ fun MediaItemVertical_2perRow(
 fun MediaItemVertical_2perRowPlaceholder(
     modifier: Modifier = Modifier
 ) {
+
     Column(
         modifier = modifier
             .size(
@@ -164,25 +180,26 @@ fun MediaItemVertical_2perRowPlaceholder(
 fun MediaItemVertical_2perRowPreview() {
     MoeListTheme {
         Surface {
-            val _textColor = Color(200,200,200);
-
             MediaItemVertical_2perRow (
                 imageUrl = null,
                 title = "This is a very large anime title that should serve as a preview example",
                 subtitle = {
                     SmallScoreIndicator(
-                        score = 8.34f,
-                        fontSize = 14.sp,
-                        textColor = _textColor,
+                        score = 8.55f,
+                        textColor = DarkTheme_textColor,
+                        fontSize = 15.sp,
+                        lineHeight =  16.sp,
+                        iconPaddingEnd= 4.dp,
                     )
                 },
                 subtitle2 = {
                         TextIconHorizontal(
-                            text = "222.123",
+                            text = "200.555",
                             icon = R.drawable.ic_round_group_24,
-                            color = _textColor,
+                            color = DarkTheme_textColor,
                             fontSize = 13.sp,
-                            iconSize = 16.dp
+                            iconSize = 16.dp,
+                            lineHeight =  16.sp,
                         )
                 },
                 onClick = {}

--- a/app/src/main/java/com/axiel7/moelist/ui/composables/score/ScoreIndicator.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/composables/score/ScoreIndicator.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -23,7 +24,10 @@ fun SmallScoreIndicator(
     score: Float?,
     modifier: Modifier = Modifier,
     fontSize: TextUnit = 14.sp,
-) {
+    textColor: Color = MaterialTheme.colorScheme.outline,
+    ) {
+
+
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically
@@ -31,12 +35,12 @@ fun SmallScoreIndicator(
         Icon(
             painter = painterResource(R.drawable.ic_round_star_16),
             contentDescription = stringResource(R.string.mean_score),
-            tint = MaterialTheme.colorScheme.outline
+            tint = textColor
         )
         Text(
             text = score.toStringPositiveValueOrUnknown(),
             modifier = Modifier.padding(horizontal = 4.dp),
-            color = MaterialTheme.colorScheme.outline,
+            color = textColor,
             fontSize = fontSize
         )
     }

--- a/app/src/main/java/com/axiel7/moelist/ui/composables/score/ScoreIndicator.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/composables/score/ScoreIndicator.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -25,6 +26,8 @@ fun SmallScoreIndicator(
     modifier: Modifier = Modifier,
     fontSize: TextUnit = 14.sp,
     textColor: Color = MaterialTheme.colorScheme.outline,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    iconPaddingEnd: Dp = 0.dp,
     ) {
 
 
@@ -33,15 +36,17 @@ fun SmallScoreIndicator(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
+            modifier = Modifier.padding(end = iconPaddingEnd),
             painter = painterResource(R.drawable.ic_round_star_16),
             contentDescription = stringResource(R.string.mean_score),
-            tint = textColor
+            tint = textColor,
         )
         Text(
             text = score.toStringPositiveValueOrUnknown(),
-            modifier = Modifier.padding(horizontal = 4.dp),
+            modifier = Modifier.padding(horizontal = 4.dp ),
             color = textColor,
-            fontSize = fontSize
+            fontSize = fontSize,
+            lineHeight = lineHeight,//fontSize*1.2,
         )
     }
 }

--- a/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
@@ -46,12 +46,6 @@ import com.axiel7.moelist.data.model.media.MediaType
 import com.axiel7.moelist.ui.base.navigation.NavActionManager
 import com.axiel7.moelist.ui.composables.DefaultScaffoldWithTopAppBar
 import com.axiel7.moelist.ui.composables.TextIconHorizontal
-import com.axiel7.moelist.ui.composables.media.MEDIA_POSTER_SMALL_WIDTH
-import com.axiel7.moelist.ui.composables.media.MEDIA_POSTER_SMALL_WIDTH_2pr
-import com.axiel7.moelist.ui.composables.media.MediaItemDetailedPlaceholder
-import com.axiel7.moelist.ui.composables.media.MediaItemVertical
-import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRow
-import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRowPlaceholder
 import com.axiel7.moelist.ui.composables.score.SmallScoreIndicator
 import com.axiel7.moelist.ui.season.composables.SeasonChartFilterSheet
 import com.axiel7.moelist.ui.theme.MoeListTheme
@@ -60,18 +54,16 @@ import com.axiel7.moelist.utils.NumExtensions.format
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 
-//val Teal200 = Color(0xFF03DAC5)
-val DarkTheme_textColor = Color(200, 200, 200)
+import com.axiel7.moelist.ui.composables.media.MediaItemDetailedPlaceholder
+import com.axiel7.moelist.ui.composables.media.MediaItemVertical
+import com.axiel7.moelist.ui.composables.media.DarkTheme_textColor
+import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRow
+import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRowPlaceholder
+import com.axiel7.moelist.ui.composables.media.getGridCellFixed_Count_ForOrientation
+import com.axiel7.moelist.ui.composables.media.MEDIA_POSTER_SMALL_WIDTH
+import com.axiel7.moelist.ui.composables.media.MEDIA_POSTER_SMALL_WIDTH_2pr
+import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRowPreview
 
-@Composable
-fun getGridCellFixed_Count_ForOrientation():Int
-{
-    var orient = LocalConfiguration.current.orientation
-    if(orient == Configuration.ORIENTATION_LANDSCAPE)
-        return 3
-    else
-        return 2
-}
 
 @Composable
 fun SeasonChartView(
@@ -155,9 +147,9 @@ private fun SeasonChartViewContent(
                 end = 2.dp,
                 bottom = bottomBarPadding
             ),
-            verticalArrangement = Arrangement.spacedBy(4.dp),
-            horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterHorizontally)
-        ) {
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(0.dp, Alignment.CenterHorizontally)
+         ) {
             items(
                 items = uiState.animes,
                 key = { it.node.id },
@@ -173,9 +165,11 @@ private fun SeasonChartViewContent(
                         subtitle = {
                             SmallScoreIndicator(
                                 score = item.node.mean,
-                                fontSize = 13.sp,
                                 textColor = DarkTheme_textColor,
-                            )
+                                fontSize = 15.sp,
+                                lineHeight =  16.sp,
+                                iconPaddingEnd= 4.dp,
+                                )
                         },
                         subtitle2 = {
                             item.node.numListUsers?.format()?.let { users ->
@@ -184,8 +178,9 @@ private fun SeasonChartViewContent(
                                     icon = R.drawable.ic_round_group_24,
                                     color = DarkTheme_textColor,
                                     fontSize = 13.sp,
-                                    iconSize = 16.dp
-                                )
+                                    iconSize = 16.dp,
+                                    lineHeight =  16.sp,
+                                    )
                             }
                         },
                         minLines = 2,
@@ -196,9 +191,10 @@ private fun SeasonChartViewContent(
                 }
             }
             if (uiState.isLoading) {
-                items(11) {
+                items(5) {
                     MediaItemVertical_2perRowPlaceholder()
-                    //MediaItemDetailedPlaceholder()
+//                    MediaItemVertical_2perRowPreview()//debug
+//                    MediaItemDetailedPlaceholder()
                 }
             }
             item(contentType = { 0 }) {

--- a/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
@@ -1,5 +1,6 @@
 package com.axiel7.moelist.ui.season
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -31,6 +32,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -59,8 +61,17 @@ import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 
 //val Teal200 = Color(0xFF03DAC5)
-val _textColor = Color(200, 200, 200);
+val DarkTheme_textColor = Color(200, 200, 200)
 
+@Composable
+fun getGridCellFixed_Count_ForOrientation():Int
+{
+    var orient = LocalConfiguration.current.orientation
+    if(orient == Configuration.ORIENTATION_LANDSCAPE)
+        return 3
+    else
+        return 2
+}
 
 @Composable
 fun SeasonChartView(
@@ -91,7 +102,6 @@ private fun SeasonChartViewContent(
     fun hideSheet() {
         scope.launch { sheetState.hide() }.invokeOnCompletion { showSheet = false }
     }
-
     val bottomBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
 
     if (showSheet) {
@@ -133,8 +143,9 @@ private fun SeasonChartViewContent(
             .only(WindowInsetsSides.Horizontal)
     ) { padding ->
         LazyVerticalGrid(
-            //columns = GridCells.Adaptive(minSize = MEDIA_POSTER_SMALL_WIDTH_2pr.dp),
-            columns = GridCells.Fixed(2),
+//            columns = GridCells.Adaptive(minSize = MEDIA_POSTER_SMALL_WIDTH_2pr.dp),
+//            columns = GridCells.Fixed(2),
+            columns = GridCells.Fixed(getGridCellFixed_Count_ForOrientation() ),
             modifier = Modifier
                 .padding(padding)
                 .fillMaxSize(),
@@ -156,8 +167,6 @@ private fun SeasonChartViewContent(
                     modifier = Modifier.fillMaxWidth(),
                     contentAlignment = Alignment.TopCenter
                 ) {
-//                    val _textColor = Color(200,200,200);
-
                     MediaItemVertical_2perRow(
                         imageUrl = item.node.mainPicture?.large,
                         title = item.node.userPreferredTitle(),
@@ -165,7 +174,7 @@ private fun SeasonChartViewContent(
                             SmallScoreIndicator(
                                 score = item.node.mean,
                                 fontSize = 13.sp,
-                                textColor = _textColor,
+                                textColor = DarkTheme_textColor,
                             )
                         },
                         subtitle2 = {
@@ -173,7 +182,7 @@ private fun SeasonChartViewContent(
                                 TextIconHorizontal(
                                     text = users,
                                     icon = R.drawable.ic_round_group_24,
-                                    color = _textColor,
+                                    color = DarkTheme_textColor,
                                     fontSize = 13.sp,
                                     iconSize = 16.dp
                                 )

--- a/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -44,8 +45,11 @@ import com.axiel7.moelist.ui.base.navigation.NavActionManager
 import com.axiel7.moelist.ui.composables.DefaultScaffoldWithTopAppBar
 import com.axiel7.moelist.ui.composables.TextIconHorizontal
 import com.axiel7.moelist.ui.composables.media.MEDIA_POSTER_SMALL_WIDTH
+import com.axiel7.moelist.ui.composables.media.MEDIA_POSTER_SMALL_WIDTH_2pr
 import com.axiel7.moelist.ui.composables.media.MediaItemDetailedPlaceholder
 import com.axiel7.moelist.ui.composables.media.MediaItemVertical
+import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRow
+import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRowPlaceholder
 import com.axiel7.moelist.ui.composables.score.SmallScoreIndicator
 import com.axiel7.moelist.ui.season.composables.SeasonChartFilterSheet
 import com.axiel7.moelist.ui.theme.MoeListTheme
@@ -53,6 +57,10 @@ import com.axiel7.moelist.utils.ContextExtensions.showToast
 import com.axiel7.moelist.utils.NumExtensions.format
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
+
+//val Teal200 = Color(0xFF03DAC5)
+val _textColor = Color(200, 200, 200);
+
 
 @Composable
 fun SeasonChartView(
@@ -125,18 +133,19 @@ private fun SeasonChartViewContent(
             .only(WindowInsetsSides.Horizontal)
     ) { padding ->
         LazyVerticalGrid(
-            columns = GridCells.Adaptive(minSize = MEDIA_POSTER_SMALL_WIDTH.dp),
+            //columns = GridCells.Adaptive(minSize = MEDIA_POSTER_SMALL_WIDTH_2pr.dp),
+            columns = GridCells.Fixed(2),
             modifier = Modifier
                 .padding(padding)
                 .fillMaxSize(),
             contentPadding = PaddingValues(
-                start = 8.dp,
+                start = 2.dp,
                 top = 8.dp,
-                end = 8.dp,
+                end = 2.dp,
                 bottom = bottomBarPadding
             ),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterHorizontally)
         ) {
             items(
                 items = uiState.animes,
@@ -147,13 +156,16 @@ private fun SeasonChartViewContent(
                     modifier = Modifier.fillMaxWidth(),
                     contentAlignment = Alignment.TopCenter
                 ) {
-                    MediaItemVertical(
+//                    val _textColor = Color(200,200,200);
+
+                    MediaItemVertical_2perRow(
                         imageUrl = item.node.mainPicture?.large,
                         title = item.node.userPreferredTitle(),
                         subtitle = {
                             SmallScoreIndicator(
                                 score = item.node.mean,
-                                fontSize = 13.sp
+                                fontSize = 13.sp,
+                                textColor = _textColor,
                             )
                         },
                         subtitle2 = {
@@ -161,7 +173,7 @@ private fun SeasonChartViewContent(
                                 TextIconHorizontal(
                                     text = users,
                                     icon = R.drawable.ic_round_group_24,
-                                    color = MaterialTheme.colorScheme.outline,
+                                    color = _textColor,
                                     fontSize = 13.sp,
                                     iconSize = 16.dp
                                 )
@@ -175,8 +187,9 @@ private fun SeasonChartViewContent(
                 }
             }
             if (uiState.isLoading) {
-                items(12) {
-                    MediaItemDetailedPlaceholder()
+                items(11) {
+                    MediaItemVertical_2perRowPlaceholder()
+                    //MediaItemDetailedPlaceholder()
                 }
             }
             item(contentType = { 0 }) {

--- a/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.compose.dropUnlessResumed
 import com.axiel7.moelist.R
+import com.axiel7.moelist.data.model.anime.AnimeSeasonal
 import com.axiel7.moelist.data.model.media.MediaType
 import com.axiel7.moelist.ui.base.navigation.NavActionManager
 import com.axiel7.moelist.ui.composables.DefaultScaffoldWithTopAppBar
@@ -147,8 +148,8 @@ private fun SeasonChartViewContent(
                 end = 2.dp,
                 bottom = bottomBarPadding
             ),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(0.dp, Alignment.CenterHorizontally)
+            verticalArrangement = Arrangement.spacedBy(26.dp),
+            horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterHorizontally)
          ) {
             items(
                 items = uiState.animes,
@@ -163,24 +164,11 @@ private fun SeasonChartViewContent(
                         imageUrl = item.node.mainPicture?.large,
                         title = item.node.userPreferredTitle(),
                         subtitle = {
-                            SmallScoreIndicator(
-                                score = item.node.mean,
-                                textColor = DarkTheme_textColor,
-                                fontSize = 15.sp,
-                                lineHeight =  16.sp,
-                                iconPaddingEnd= 4.dp,
-                                )
+                            SmallScoreIndicator_Style1(item)
                         },
                         subtitle2 = {
                             item.node.numListUsers?.format()?.let { users ->
-                                TextIconHorizontal(
-                                    text = users,
-                                    icon = R.drawable.ic_round_group_24,
-                                    color = DarkTheme_textColor,
-                                    fontSize = 13.sp,
-                                    iconSize = 16.dp,
-                                    lineHeight =  16.sp,
-                                    )
+                                SmallMemberIndicator_Style1(users)
                             }
                         },
                         minLines = 2,
@@ -204,6 +192,30 @@ private fun SeasonChartViewContent(
             }
         }
     }//:Scaffold
+}
+
+//Concise Overloads - Move to ScoreIndicator.kt
+@Composable
+private fun SmallMemberIndicator_Style1(users: String) {
+    TextIconHorizontal(
+        text = users,
+        icon = R.drawable.ic_round_group_24,
+        color = DarkTheme_textColor,
+        fontSize = 13.sp,
+        iconSize = 16.dp,
+        lineHeight = 16.sp,
+    )
+}
+
+@Composable
+private fun SmallScoreIndicator_Style1(item: AnimeSeasonal) {
+    SmallScoreIndicator(
+        score = item.node.mean,
+        textColor = DarkTheme_textColor,
+        fontSize = 15.sp,
+        lineHeight = 16.sp,
+        iconPaddingEnd = 4.dp,
+    )
 }
 
 @Preview


### PR DESCRIPTION
currently i switch back to forth between Official MapApp and Moelist.

 due to Moelist  SeasonView   images being too small.  
 
SeasonView is  The Most important  Page For Casual Anime Fans.
big photos are really helpful, when discovering new animes .
  
 so i wanted to bring it over here.





|  mal app official |  moelist 3 .7.1 patch day2  |   ----------------  | 
| ----------------- | -------------------------- | ------------------------- | 
|      ![ss-mal-450px](https://github.com/user-attachments/assets/fa770f86-5cea-4714-afc6-3d028d18f210)     |    ![ss_moelist -day2_450px](https://github.com/user-attachments/assets/2417d94f-e330-411f-9e21-293af7f32b2f)   |    - | 

