### PR TITLE
SeasonView  - 2 item per row

### DIFF
--- a/app/src/main/java/com/axiel7/moelist/ui/composables/TextIcon.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/composables/TextIcon.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
@@ -36,6 +37,7 @@ fun TextIconHorizontal(
     color: Color = MaterialTheme.colorScheme.onSurfaceVariant,
     fontSize: TextUnit = TextUnit.Unspecified,
     iconSize: Dp = 24.dp,
+    lineHeight: TextUnit = TextUnit.Unspecified,
 ) {
     Row(
         modifier = modifier,
@@ -53,10 +55,21 @@ fun TextIconHorizontal(
             text = text,
             modifier = Modifier.padding(horizontal = 4.dp),
             color = color,
-            fontSize = fontSize
+            fontSize = fontSize,
+            lineHeight = lineHeight,
         )
     }
 }
+
+@Preview(showBackground = true)
+@Composable
+fun TextIconHorizontalPreview() {
+    MoeListTheme {
+        TextIconHorizontal(text = "This is an example", icon = R.drawable.ic_round_details_star_24)
+    }
+}
+
+
 
 @Composable
 fun TextIconVertical(
@@ -118,13 +131,6 @@ fun TextIconVertical(
     }
 }
 
-@Preview(showBackground = true)
-@Composable
-fun TextIconHorizontalPreview() {
-    MoeListTheme {
-        TextIconHorizontal(text = "This is an example", icon = R.drawable.ic_round_details_star_24)
-    }
-}
 
 @Preview(showBackground = true)
 @Composable

--- a/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaItemVertical_2perRow.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaItemVertical_2perRow.kt
@@ -1,0 +1,213 @@
+package com.axiel7.moelist.ui.composables.media
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContentPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.axiel7.moelist.R
+import com.axiel7.moelist.ui.composables.TextIconHorizontal
+import com.axiel7.moelist.ui.composables.defaultPlaceholder
+import com.axiel7.moelist.ui.composables.score.SmallScoreIndicator
+import com.axiel7.moelist.ui.theme.MoeListTheme
+import com.axiel7.moelist.utils.NumExtensions.format
+
+//MAL app style. 2perRow - its easier to see poster on phoneScreen.
+const val multi =2.0;
+const val MEDIA_POSTER_COMPACT_HEIGHT_2pr = 100*multi
+const val MEDIA_POSTER_COMPACT_WIDTH_2pr = 100*multi
+
+const val MEDIA_POSTER_SMALL_HEIGHT_2pr = 140*multi
+const val MEDIA_POSTER_SMALL_WIDTH_2pr = 100*multi  +20 //+100 see if img is centered
+
+const val MEDIA_POSTER_MEDIUM_HEIGHT_2pr = 156*multi
+const val MEDIA_POSTER_MEDIUM_WIDTH_2pr = 110*multi
+
+const val MEDIA_POSTER_BIG_HEIGHT_2pr = 213*multi
+const val MEDIA_POSTER_BIG_WIDTH_2pr = 150*multi
+
+const val MEDIA_ITEM_VERTICAL_HEIGHT_2pr = (156+25)*multi
+
+//val Teal200 = Color(0xFF03DAC5)
+val DarkTheme_textColor = Color(220, 220, 220)
+
+
+@Composable
+fun getGridCellFixed_Count_ForOrientation():Int
+{
+    val orient = LocalConfiguration.current.orientation
+    val landScape = Configuration.ORIENTATION_LANDSCAPE
+
+    val count = if(orient == landScape ) 3 else 2
+    return  count
+}
+
+
+@Composable
+fun MediaItemVertical_2perRow(
+    title: String,
+    imageUrl: String?,
+    modifier: Modifier = Modifier,
+    subtitle: @Composable (() -> Unit)? = null,
+    subtitle2: @Composable (() -> Unit)? = null,
+    minLines: Int = 1,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .width(MEDIA_POSTER_SMALL_WIDTH_2pr.dp)
+            //.width(300.dp)
+            .sizeIn(
+                minHeight = MEDIA_ITEM_VERTICAL_HEIGHT_2pr.dp -60.dp // -100.dp
+            )
+            .clip(RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        /*Poster And StartCount Container - use box to overlay*/
+        Box(
+            modifier = modifier
+                .fillMaxWidth(),
+            contentAlignment = Alignment.BottomStart
+        )
+        {
+            //layer1
+            MediaPoster(
+                url = imageUrl,
+                modifier = Modifier
+                    .size(
+                        width = MEDIA_POSTER_MEDIUM_WIDTH_2pr.dp  ,
+                        height = MEDIA_POSTER_MEDIUM_HEIGHT_2pr.dp -50.dp
+                    ),
+            )
+            //layer2 - StartCount -PeopleCount
+            Column(
+                modifier = modifier
+                    .offset(x=4.dp ,y= -15.dp)
+                    .background(Color.DarkGray)
+                    .padding(vertical = 3.dp, horizontal = 0.dp),
+//                horizontalAlignment = Alignment.Start,
+            )
+            {
+                subtitle?.let { it() }
+                subtitle2?.let { it() }
+            }
+
+        }
+
+
+        Text(
+            text = title,
+            modifier = Modifier
+                .width(MEDIA_POSTER_SMALL_WIDTH_2pr.dp)
+                .padding(top = 0.dp, bottom = 4.dp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 15.sp,
+            lineHeight = 18.sp,
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 2,
+            minLines = minLines
+        )
+
+
+    }
+}
+
+
+
+@Preview // for debug
+@Composable
+fun MediaItemVertical_2perRowPlaceholder(
+    modifier: Modifier = Modifier
+) {
+
+    Column(
+        modifier = modifier
+            .size(
+                width = (MEDIA_POSTER_SMALL_WIDTH_2pr ).dp,
+                height = MEDIA_ITEM_VERTICAL_HEIGHT_2pr.dp -60.dp
+            )
+            //.padding(end = 8.dp ),
+            .padding(start = 8.dp,end = 8.dp, top=4.dp ),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = Modifier
+                .size(
+//                    width = MEDIA_POSTER_SMALL_WIDTH_2pr.dp,
+//                    height = MEDIA_POSTER_SMALL_HEIGHT_2pr.dp +14.dp
+                    width = MEDIA_POSTER_MEDIUM_WIDTH_2pr.dp,
+                    height = MEDIA_POSTER_MEDIUM_HEIGHT_2pr.dp -6.dp -50.dp
+                )
+                .padding( bottom=4.dp )
+                .defaultPlaceholder(visible = true)
+        )
+
+        Text(
+            text = "This is a placeholder - i need to make it 2 lines  ",
+            modifier = Modifier
+                .padding(top = 4.dp)
+                .defaultPlaceholder(visible = true),
+            fontSize = 15.sp,
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 2
+        )
+    }
+}
+
+@Preview
+@Composable
+fun MediaItemVertical_2perRowPreview() {
+    MoeListTheme {
+        Surface {
+            MediaItemVertical_2perRow (
+                imageUrl = null,
+                title = "This is a very large anime title that should serve as a preview example",
+                subtitle = {
+                    SmallScoreIndicator(
+                        score = 8.55f,
+                        textColor = DarkTheme_textColor,
+                        fontSize = 15.sp,
+                        lineHeight =  16.sp,
+                        iconPaddingEnd= 4.dp,
+                    )
+                },
+                subtitle2 = {
+                        TextIconHorizontal(
+                            text = "200.555",
+                            icon = R.drawable.ic_round_group_24,
+                            color = DarkTheme_textColor,
+                            fontSize = 13.sp,
+                            iconSize = 16.dp,
+                            lineHeight =  16.sp,
+                        )
+                },
+                onClick = {}
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaItemVertical_2perRow.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaItemVertical_2perRow.kt
@@ -6,17 +6,16 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeContentPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -26,16 +25,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.axiel7.moelist.R
+import com.axiel7.moelist.data.model.media.ListStatus
 import com.axiel7.moelist.ui.composables.TextIconHorizontal
 import com.axiel7.moelist.ui.composables.defaultPlaceholder
 import com.axiel7.moelist.ui.composables.score.SmallScoreIndicator
 import com.axiel7.moelist.ui.theme.MoeListTheme
-import com.axiel7.moelist.utils.NumExtensions.format
 
 //MAL app style. 2perRow - its easier to see poster on phoneScreen.
 const val multi =2.0;
@@ -71,6 +71,7 @@ fun getGridCellFixed_Count_ForOrientation():Int
 @Composable
 fun MediaItemVertical_2perRow(
     title: String,
+    status: ListStatus?,
     imageUrl: String?,
     modifier: Modifier = Modifier,
     badgeContent: @Composable (RowScope.() -> Unit)? = null,
@@ -110,6 +111,7 @@ fun MediaItemVertical_2perRow(
             Column(
                 modifier = modifier
                     .offset(x=4.dp ,y= -15.dp)
+                    .clip(RoundedCornerShape(topEnd = 8.dp, bottomEnd = 8.dp))
                     .background(Color.DarkGray)
                     .padding(vertical = 3.dp, horizontal = 0.dp),
 //                horizontalAlignment = Alignment.Start,
@@ -118,6 +120,25 @@ fun MediaItemVertical_2perRow(
                 subtitle?.let { it() }
                 subtitle2?.let { it() }
             }
+
+            //layer3 - badge content - at user list indicator
+            if (badgeContent != null) {
+                Row(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .offset(x=-4.dp ,y= -15.dp)
+                        .clip(RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp))
+                        //.background(MaterialTheme.colorScheme.primaryContainer)
+                        .background(getStatusColor(status = status))
+                        .padding(horizontal = 8.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.End,
+                    content = badgeContent
+                )
+            }
+
+
+
 
         }
 
@@ -189,6 +210,14 @@ fun MediaItemVertical_2perRowPreview() {
             MediaItemVertical_2perRow (
                 imageUrl = null,
                 title = "This is a very large anime title that should serve as a preview example",
+                status = ListStatus.WATCHING,
+                badgeContent = {
+                    Icon(
+                        painter = painterResource(R.drawable.check_circle_outline_24),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                },
                 subtitle = {
                     SmallScoreIndicator(
                         score = 8.55f,

--- a/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaItemVertical_2perRow.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaItemVertical_2perRow.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -72,6 +73,7 @@ fun MediaItemVertical_2perRow(
     title: String,
     imageUrl: String?,
     modifier: Modifier = Modifier,
+    badgeContent: @Composable (RowScope.() -> Unit)? = null,
     subtitle: @Composable (() -> Unit)? = null,
     subtitle2: @Composable (() -> Unit)? = null,
     minLines: Int = 1,

--- a/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaPoster.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/composables/media/MediaPoster.kt
@@ -44,7 +44,7 @@ fun MediaPoster(
         modifier = modifier
             .then(
                 if (showShadow) Modifier
-                    .padding(start = 4.dp, top = 2.dp, end = 4.dp, bottom = 8.dp)
+                    .padding(start = 4.dp, top = 2.dp, end = 4.dp, bottom = 4.dp)
                     .shadow(4.dp, shape = RoundedCornerShape(8.dp))
                 else Modifier
             )

--- a/app/src/main/java/com/axiel7/moelist/ui/composables/media/getStatusColor.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/composables/media/getStatusColor.kt
@@ -1,0 +1,24 @@
+package com.axiel7.moelist.ui.composables.media
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.axiel7.moelist.data.model.media.ListStatus
+
+val StatusWatching = Color(0xFF2DB039)
+val StatusPlanned = Color(0xFFC3C3C3)
+val StatusCompleted = Color(0xFF26448f)
+val StatusOnHold = Color(0xFFf1c83e)
+val StatusDropped = Color(0xFFa12f31)
+
+@Composable
+fun getStatusColor(status: ListStatus?): Color {
+    return when (status) {
+        ListStatus.WATCHING, ListStatus.READING -> StatusWatching
+        ListStatus.PLAN_TO_WATCH,ListStatus.PLAN_TO_READ -> StatusPlanned
+        ListStatus.COMPLETED -> StatusCompleted
+        ListStatus.ON_HOLD -> StatusOnHold
+        ListStatus.DROPPED -> StatusDropped
+        else -> MaterialTheme.colorScheme.primaryContainer // A sensible default
+    }
+}

--- a/app/src/main/java/com/axiel7/moelist/ui/composables/score/ScoreIndicator.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/composables/score/ScoreIndicator.kt
@@ -8,9 +8,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -23,21 +25,28 @@ fun SmallScoreIndicator(
     score: Float?,
     modifier: Modifier = Modifier,
     fontSize: TextUnit = 14.sp,
-) {
+    textColor: Color = MaterialTheme.colorScheme.outline,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    iconPaddingEnd: Dp = 0.dp,
+    ) {
+
+
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
+            modifier = Modifier.padding(end = iconPaddingEnd),
             painter = painterResource(R.drawable.ic_round_star_16),
             contentDescription = stringResource(R.string.mean_score),
-            tint = MaterialTheme.colorScheme.outline
+            tint = textColor,
         )
         Text(
             text = score.toStringPositiveValueOrUnknown(),
-            modifier = Modifier.padding(horizontal = 4.dp),
-            color = MaterialTheme.colorScheme.outline,
-            fontSize = fontSize
+            modifier = Modifier.padding(horizontal = 4.dp ),
+            color = textColor,
+            fontSize = fontSize,
+            lineHeight = lineHeight,//fontSize*1.2,
         )
     }
 }

--- a/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
@@ -1,5 +1,6 @@
 package com.axiel7.moelist.ui.season
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -30,6 +31,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -39,13 +42,11 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.compose.dropUnlessResumed
 import com.axiel7.moelist.R
+import com.axiel7.moelist.data.model.anime.AnimeSeasonal
 import com.axiel7.moelist.data.model.media.MediaType
 import com.axiel7.moelist.ui.base.navigation.NavActionManager
 import com.axiel7.moelist.ui.composables.DefaultScaffoldWithTopAppBar
 import com.axiel7.moelist.ui.composables.TextIconHorizontal
-import com.axiel7.moelist.ui.composables.media.MEDIA_POSTER_SMALL_WIDTH
-import com.axiel7.moelist.ui.composables.media.MediaItemDetailedPlaceholder
-import com.axiel7.moelist.ui.composables.media.MediaItemVertical
 import com.axiel7.moelist.ui.composables.score.SmallScoreIndicator
 import com.axiel7.moelist.ui.season.composables.SeasonChartFilterSheet
 import com.axiel7.moelist.ui.theme.MoeListTheme
@@ -53,6 +54,17 @@ import com.axiel7.moelist.utils.ContextExtensions.showToast
 import com.axiel7.moelist.utils.NumExtensions.format
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
+
+import com.axiel7.moelist.ui.composables.media.MediaItemDetailedPlaceholder
+import com.axiel7.moelist.ui.composables.media.MediaItemVertical
+import com.axiel7.moelist.ui.composables.media.DarkTheme_textColor
+import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRow
+import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRowPlaceholder
+import com.axiel7.moelist.ui.composables.media.getGridCellFixed_Count_ForOrientation
+import com.axiel7.moelist.ui.composables.media.MEDIA_POSTER_SMALL_WIDTH
+import com.axiel7.moelist.ui.composables.media.MEDIA_POSTER_SMALL_WIDTH_2pr
+import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRowPreview
+
 
 @Composable
 fun SeasonChartView(
@@ -83,7 +95,6 @@ private fun SeasonChartViewContent(
     fun hideSheet() {
         scope.launch { sheetState.hide() }.invokeOnCompletion { showSheet = false }
     }
-
     val bottomBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
 
     if (showSheet) {
@@ -125,19 +136,21 @@ private fun SeasonChartViewContent(
             .only(WindowInsetsSides.Horizontal)
     ) { padding ->
         LazyVerticalGrid(
-            columns = GridCells.Adaptive(minSize = MEDIA_POSTER_SMALL_WIDTH.dp),
+//            columns = GridCells.Adaptive(minSize = MEDIA_POSTER_SMALL_WIDTH_2pr.dp),
+//            columns = GridCells.Fixed(2),
+            columns = GridCells.Fixed(getGridCellFixed_Count_ForOrientation() ),
             modifier = Modifier
                 .padding(padding)
                 .fillMaxSize(),
             contentPadding = PaddingValues(
-                start = 8.dp,
+                start = 2.dp,
                 top = 8.dp,
-                end = 8.dp,
+                end = 2.dp,
                 bottom = bottomBarPadding
             ),
             verticalArrangement = Arrangement.spacedBy(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)
-        ) {
+            horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterHorizontally)
+         ) {
             items(
                 items = uiState.animes,
                 key = { it.node.id },
@@ -147,24 +160,15 @@ private fun SeasonChartViewContent(
                     modifier = Modifier.fillMaxWidth(),
                     contentAlignment = Alignment.TopCenter
                 ) {
-                    MediaItemVertical(
+                    MediaItemVertical_2perRow(
                         imageUrl = item.node.mainPicture?.large,
                         title = item.node.userPreferredTitle(),
                         subtitle = {
-                            SmallScoreIndicator(
-                                score = item.node.mean,
-                                fontSize = 13.sp
-                            )
+                            SmallScoreIndicator_Style1(item)
                         },
                         subtitle2 = {
                             item.node.numListUsers?.format()?.let { users ->
-                                TextIconHorizontal(
-                                    text = users,
-                                    icon = R.drawable.ic_round_group_24,
-                                    color = MaterialTheme.colorScheme.outline,
-                                    fontSize = 13.sp,
-                                    iconSize = 16.dp
-                                )
+                                SmallMemberIndicator_Style1(users)
                             }
                         },
                         minLines = 2,
@@ -175,8 +179,10 @@ private fun SeasonChartViewContent(
                 }
             }
             if (uiState.isLoading) {
-                items(12) {
-                    MediaItemDetailedPlaceholder()
+                items(5) {
+                    MediaItemVertical_2perRowPlaceholder()
+//                    MediaItemVertical_2perRowPreview()//debug
+//                    MediaItemDetailedPlaceholder()
                 }
             }
             item(contentType = { 0 }) {
@@ -186,6 +192,30 @@ private fun SeasonChartViewContent(
             }
         }
     }//:Scaffold
+}
+
+//Concise Overloads - Move to ScoreIndicator.kt
+@Composable
+private fun SmallMemberIndicator_Style1(users: String) {
+    TextIconHorizontal(
+        text = users,
+        icon = R.drawable.ic_round_group_24,
+        color = DarkTheme_textColor,
+        fontSize = 13.sp,
+        iconSize = 16.dp,
+        lineHeight = 16.sp,
+    )
+}
+
+@Composable
+private fun SmallScoreIndicator_Style1(item: AnimeSeasonal) {
+    SmallScoreIndicator(
+        score = item.node.mean,
+        textColor = DarkTheme_textColor,
+        fontSize = 15.sp,
+        lineHeight = 16.sp,
+        iconPaddingEnd = 4.dp,
+    )
 }
 
 @Preview

--- a/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
@@ -1,5 +1,6 @@
 package com.axiel7.moelist.ui.season
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -30,6 +31,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -39,13 +42,11 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.compose.dropUnlessResumed
 import com.axiel7.moelist.R
+import com.axiel7.moelist.data.model.anime.AnimeSeasonal
 import com.axiel7.moelist.data.model.media.MediaType
 import com.axiel7.moelist.ui.base.navigation.NavActionManager
 import com.axiel7.moelist.ui.composables.DefaultScaffoldWithTopAppBar
 import com.axiel7.moelist.ui.composables.TextIconHorizontal
-import com.axiel7.moelist.ui.composables.media.MEDIA_POSTER_SMALL_WIDTH
-import com.axiel7.moelist.ui.composables.media.MediaItemDetailedPlaceholder
-import com.axiel7.moelist.ui.composables.media.MediaItemVertical
 import com.axiel7.moelist.ui.composables.score.SmallScoreIndicator
 import com.axiel7.moelist.ui.season.composables.SeasonChartFilterSheet
 import com.axiel7.moelist.ui.theme.MoeListTheme
@@ -53,6 +54,17 @@ import com.axiel7.moelist.utils.ContextExtensions.showToast
 import com.axiel7.moelist.utils.NumExtensions.format
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
+
+import com.axiel7.moelist.ui.composables.media.MediaItemDetailedPlaceholder
+import com.axiel7.moelist.ui.composables.media.MediaItemVertical
+import com.axiel7.moelist.ui.composables.media.DarkTheme_textColor
+import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRow
+import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRowPlaceholder
+import com.axiel7.moelist.ui.composables.media.getGridCellFixed_Count_ForOrientation
+import com.axiel7.moelist.ui.composables.media.MEDIA_POSTER_SMALL_WIDTH
+import com.axiel7.moelist.ui.composables.media.MEDIA_POSTER_SMALL_WIDTH_2pr
+import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRowPreview
+
 
 @Composable
 fun SeasonChartView(
@@ -83,7 +95,6 @@ private fun SeasonChartViewContent(
     fun hideSheet() {
         scope.launch { sheetState.hide() }.invokeOnCompletion { showSheet = false }
     }
-
     val bottomBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
 
     if (showSheet) {
@@ -125,19 +136,21 @@ private fun SeasonChartViewContent(
             .only(WindowInsetsSides.Horizontal)
     ) { padding ->
         LazyVerticalGrid(
-            columns = GridCells.Adaptive(minSize = MEDIA_POSTER_SMALL_WIDTH.dp),
+//            columns = GridCells.Adaptive(minSize = MEDIA_POSTER_SMALL_WIDTH_2pr.dp),
+//            columns = GridCells.Fixed(2),
+            columns = GridCells.Fixed(getGridCellFixed_Count_ForOrientation() ),
             modifier = Modifier
                 .padding(padding)
                 .fillMaxSize(),
             contentPadding = PaddingValues(
-                start = 8.dp,
+                start = 2.dp,
                 top = 8.dp,
-                end = 8.dp,
+                end = 2.dp,
                 bottom = bottomBarPadding
             ),
             verticalArrangement = Arrangement.spacedBy(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)
-        ) {
+            horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterHorizontally)
+         ) {
             items(
                 items = uiState.animes,
                 key = { it.node.id },
@@ -147,7 +160,7 @@ private fun SeasonChartViewContent(
                     modifier = Modifier.fillMaxWidth(),
                     contentAlignment = Alignment.TopCenter
                 ) {
-                    MediaItemVertical(
+                    MediaItemVertical_2perRow(
                         imageUrl = item.node.mainPicture?.large,
                         title = item.node.userPreferredTitle(),
                         badgeContent = item.node.myListStatus?.status?.let { status ->
@@ -158,6 +171,8 @@ private fun SeasonChartViewContent(
                                     tint = MaterialTheme.colorScheme.onPrimaryContainer
                                 )
                             }
+                        subtitle = {
+                            SmallScoreIndicator_Style1(item)
                         },
                         subtitle = if (!uiState.hideScore) {
                             {
@@ -169,13 +184,7 @@ private fun SeasonChartViewContent(
                         } else null,
                         subtitle2 = {
                             item.node.numListUsers?.format()?.let { users ->
-                                TextIconHorizontal(
-                                    text = users,
-                                    icon = R.drawable.ic_round_group_24,
-                                    color = MaterialTheme.colorScheme.outline,
-                                    fontSize = 13.sp,
-                                    iconSize = 16.dp
-                                )
+                                SmallMemberIndicator_Style1(users)
                             }
                         },
                         minLines = 2,
@@ -186,8 +195,10 @@ private fun SeasonChartViewContent(
                 }
             }
             if (uiState.isLoading) {
-                items(12) {
-                    MediaItemDetailedPlaceholder()
+                items(5) {
+                    MediaItemVertical_2perRowPlaceholder()
+//                    MediaItemVertical_2perRowPreview()//debug
+//                    MediaItemDetailedPlaceholder()
                 }
             }
             item(contentType = { 0 }) {
@@ -197,6 +208,30 @@ private fun SeasonChartViewContent(
             }
         }
     }//:Scaffold
+}
+
+//Concise Overloads - Move to ScoreIndicator.kt
+@Composable
+private fun SmallMemberIndicator_Style1(users: String) {
+    TextIconHorizontal(
+        text = users,
+        icon = R.drawable.ic_round_group_24,
+        color = DarkTheme_textColor,
+        fontSize = 13.sp,
+        iconSize = 16.dp,
+        lineHeight = 16.sp,
+    )
+}
+
+@Composable
+private fun SmallScoreIndicator_Style1(item: AnimeSeasonal) {
+    SmallScoreIndicator(
+        score = item.node.mean,
+        textColor = DarkTheme_textColor,
+        fontSize = 15.sp,
+        lineHeight = 16.sp,
+        iconPaddingEnd = 4.dp,
+    )
 }
 
 @Preview

--- a/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
@@ -1,6 +1,5 @@
 package com.axiel7.moelist.ui.season
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -31,8 +30,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -55,15 +52,10 @@ import com.axiel7.moelist.utils.NumExtensions.format
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 
-import com.axiel7.moelist.ui.composables.media.MediaItemDetailedPlaceholder
-import com.axiel7.moelist.ui.composables.media.MediaItemVertical
 import com.axiel7.moelist.ui.composables.media.DarkTheme_textColor
 import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRow
 import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRowPlaceholder
 import com.axiel7.moelist.ui.composables.media.getGridCellFixed_Count_ForOrientation
-import com.axiel7.moelist.ui.composables.media.MEDIA_POSTER_SMALL_WIDTH
-import com.axiel7.moelist.ui.composables.media.MEDIA_POSTER_SMALL_WIDTH_2pr
-import com.axiel7.moelist.ui.composables.media.MediaItemVertical_2perRowPreview
 
 
 @Composable
@@ -163,6 +155,7 @@ private fun SeasonChartViewContent(
                     MediaItemVertical_2perRow(
                             imageUrl = item.node.mainPicture?.large,
                             title = item.node.userPreferredTitle(),
+                            status = item.node.myListStatus?.status,
                             badgeContent = item.node.myListStatus?.status?.let
                             { status ->
                                 {

--- a/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
+++ b/app/src/main/java/com/axiel7/moelist/ui/season/SeasonChartView.kt
@@ -161,38 +161,33 @@ private fun SeasonChartViewContent(
                     contentAlignment = Alignment.TopCenter
                 ) {
                     MediaItemVertical_2perRow(
-                        imageUrl = item.node.mainPicture?.large,
-                        title = item.node.userPreferredTitle(),
-                        badgeContent = item.node.myListStatus?.status?.let { status ->
-                            {
-                                Icon(
-                                    painter = painterResource(status.icon),
-                                    contentDescription = status.localized(),
-                                    tint = MaterialTheme.colorScheme.onPrimaryContainer
-                                )
+                            imageUrl = item.node.mainPicture?.large,
+                            title = item.node.userPreferredTitle(),
+                            badgeContent = item.node.myListStatus?.status?.let
+                            { status ->
+                                {
+                                    Icon(
+                                        painter = painterResource(status.icon),
+                                        contentDescription = status.localized(),
+                                        tint = MaterialTheme.colorScheme.onPrimaryContainer
+                                    )
+                                }
+                            },
+                            subtitle = {
+                                SmallScoreIndicator_Style1(item)
+                            },
+                            subtitle2 = {
+                                item.node.numListUsers?.format()?.let { users ->
+                                    SmallMemberIndicator_Style1(users)
+                                }
+                            },
+                            minLines = 2,
+                            onClick = dropUnlessResumed {
+                                navActionManager.toMediaDetails(MediaType.ANIME, item.node.id)
                             }
-                        subtitle = {
-                            SmallScoreIndicator_Style1(item)
-                        },
-                        subtitle = if (!uiState.hideScore) {
-                            {
-                                SmallScoreIndicator(
-                                    score = item.node.mean,
-                                    fontSize = 13.sp
-                                )
-                            }
-                        } else null,
-                        subtitle2 = {
-                            item.node.numListUsers?.format()?.let { users ->
-                                SmallMemberIndicator_Style1(users)
-                            }
-                        },
-                        minLines = 2,
-                        onClick = dropUnlessResumed {
-                            navActionManager.toMediaDetails(MediaType.ANIME, item.node.id)
-                        }
-                    )
+                        )
                 }
+
             }
             if (uiState.isLoading) {
                 items(5) {


### PR DESCRIPTION
pushing it again.   ( messed something with github desktop  in previous PR  )

again the info...

----


currently i switch back to forth between Official MapApp and Moelist.

 due to Moelist  SeasonView   images being too small.  
 
SeasonView is  The Most important  Page For Casual Anime Fans.
big photos are really helpful, when discovering new animes .
  
 so i wanted to bring it over here.





|  mal app official |  moelist 3 .7.1 patch day2  |   ----------------  | 
| ----------------- | -------------------------- | ------------------------- | 
|      ![ss-mal-450px](https://github.com/user-attachments/assets/fa770f86-5cea-4714-afc6-3d028d18f210)     |    ![ss_moelist -day2_450px](https://github.com/user-attachments/assets/2417d94f-e330-411f-9e21-293af7f32b2f)   |    - | 




